### PR TITLE
Show overlay window on startup

### DIFF
--- a/src/DocFinder.App/Services/ApplicationHostService.cs
+++ b/src/DocFinder.App/Services/ApplicationHostService.cs
@@ -25,6 +25,8 @@ public class ApplicationHostService : IHostedService
     {
         _watcher.Start();
         _tray.Initialize(ToggleOverlay, () => Application.Current.Shutdown(), ShowSettings);
+        _overlay.Show();
+        _overlay.Activate();
         return Task.CompletedTask;
     }
 

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -8,7 +8,7 @@
     WindowCornerPreference="Round"
     WindowBackdropType="Mica"
     ResizeMode="NoResize"
-    ShowInTaskbar="False">
+    ShowInTaskbar="True">
     <Grid Margin="16">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- Ensure search overlay window displays immediately on startup and gains focus
- Allow overlay to appear in the taskbar for easier access

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b338ccd97c8326922243c0d3c9739d