### PR TITLE
Fix backdrop initialization for WPF windows

### DIFF
--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -6,6 +6,7 @@
     WindowStartupLocation="CenterScreen"
     WindowStyle="None"
     WindowCornerPreference="Round"
+    ExtendsContentIntoTitleBar="True"
     WindowBackdropType="Mica"
     ResizeMode="NoResize"
     ShowInTaskbar="True">

--- a/src/DocFinder.UI/Views/SettingsWindow.xaml
+++ b/src/DocFinder.UI/Views/SettingsWindow.xaml
@@ -4,6 +4,7 @@
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="Settings" Width="500" Height="400"
     WindowStartupLocation="CenterOwner"
+    ExtendsContentIntoTitleBar="True"
     WindowBackdropType="Mica">
     <StackPanel Margin="20">
         <TextBlock Text="Source Folder"/>


### PR DESCRIPTION
## Summary
- Extend window content into title bar when using Mica backdrop

## Testing
- `dotnet test` *(fails: Project DocFinder.Services is not compatible with net8.0 (.NETCoreApp,Version=v8.0))*

------
https://chatgpt.com/codex/tasks/task_e_68b33a54740883268c9d5df81e2332d9