### PR TITLE
Initialize config defaults and fix search overlay icon

### DIFF
--- a/src/DocFinder.App/Models/AppConfig.cs
+++ b/src/DocFinder.App/Models/AppConfig.cs
@@ -2,8 +2,8 @@
 {
     public class AppConfig
     {
-        public string ConfigurationsFolder { get; set; }
+        public string ConfigurationsFolder { get; set; } = string.Empty;
 
-        public string AppPropertiesFileName { get; set; }
+        public string AppPropertiesFileName { get; set; } = string.Empty;
     }
 }

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -19,7 +19,10 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
-        <ui:Button x:Name="MenuButton" Width="36" Height="36" Appearance="Secondary" CornerRadius="8" SymbolIcon="Navigation16" Click="MenuButton_Click">
+        <ui:Button x:Name="MenuButton" Width="36" Height="36" Appearance="Secondary" CornerRadius="8" Click="MenuButton_Click">
+            <ui:Button.Icon>
+                <ui:SymbolIcon Symbol="Navigation16"/>
+            </ui:Button.Icon>
             <ui:Button.ContextMenu>
                 <ContextMenu>
                     <MenuItem Header="New search" Click="Menu_NewSearch_Click">


### PR DESCRIPTION
## Summary
- prevent null property warnings by initializing `AppConfig` file paths
- fix SearchOverlay menu button icon by using dedicated icon element

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3426d30e08326b9b95e2f2f649352