### PR TITLE
Fix indexer DI registration and property initialization

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -26,8 +26,7 @@ public partial class App
             services.AddSingleton<ISettingsService, SettingsService>();
             services.AddSingleton<ISearchService, LuceneSearchService>();
             services.AddSingleton<CatalogRepository>();
-            services.AddSingleton<DocumentIndexer>();
-            services.AddSingleton<IIndexer>(sp => sp.GetRequiredService<DocumentIndexer>());
+            services.AddSingleton<IIndexer, DocumentIndexer>();
             services.AddSingleton<SearchOverlayViewModel>();
             services.AddSingleton<SearchOverlay>();
             services.AddSingleton<SettingsViewModel>();

--- a/src/DocFinder.App/ViewModels/Pages/DataViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Pages/DataViewModel.cs
@@ -1,49 +1,51 @@
-﻿using System.Windows.Media;
+using System;
+using System.Collections.Generic;
+using System.Windows.Media;
 using DocFinder.Models;
 using Wpf.Ui.Abstractions.Controls;
 
-namespace DocFinder.ViewModels.Pages
+namespace DocFinder.ViewModels.Pages;
+
+public partial class DataViewModel : ObservableObject, INavigationAware
 {
-    public partial class DataViewModel : ObservableObject, INavigationAware
+    private bool _isInitialized = false;
+
+    [ObservableProperty]
+    private IEnumerable<DataColor> _colors = Array.Empty<DataColor>();
+
+    public Task OnNavigatedToAsync()
     {
-        private bool _isInitialized = false;
+        if (!_isInitialized)
+            InitializeViewModel();
 
-        [ObservableProperty]
-        private IEnumerable<DataColor> _colors;
+        return Task.CompletedTask;
+    }
 
-        public Task OnNavigatedToAsync()
-        {
-            if (!_isInitialized)
-                InitializeViewModel();
+    public Task OnNavigatedFromAsync() => Task.CompletedTask;
 
-            return Task.CompletedTask;
-        }
+    private void InitializeViewModel()
+    {
+        var random = new Random();
+        var colorCollection = new List<DataColor>();
 
-        public Task OnNavigatedFromAsync() => Task.CompletedTask;
-
-        private void InitializeViewModel()
-        {
-            var random = new Random();
-            var colorCollection = new List<DataColor>();
-
-            for (int i = 0; i < 8192; i++)
-                colorCollection.Add(
-                    new DataColor
-                    {
-                        Color = new SolidColorBrush(
-                            Color.FromArgb(
-                                (byte)200,
-                                (byte)random.Next(0, 250),
-                                (byte)random.Next(0, 250),
-                                (byte)random.Next(0, 250)
-                            )
+        for (int i = 0; i < 8192; i++)
+            colorCollection.Add(
+                new DataColor
+                {
+                    Color = new SolidColorBrush(
+                        Color.FromArgb(
+                            (byte)200,
+                            (byte)random.Next(0, 250),
+                            (byte)random.Next(0, 250),
+                            (byte)random.Next(0, 250)
                         )
-                    }
-                );
+                    )
+                }
+            );
 
-            Colors = colorCollection;
+        Colors = colorCollection;
 
-            _isInitialized = true;
-        }
+        _isInitialized = true;
     }
 }
+

--- a/src/DocFinder.UI/ViewModels/SearchOverlayViewModel.cs
+++ b/src/DocFinder.UI/ViewModels/SearchOverlayViewModel.cs
@@ -46,9 +46,9 @@ public partial class SearchOverlayViewModel : ObservableObject
     [RelayCommand]
     private void OpenSelected()
     {
-        if (_selectedResult != null)
+        if (SelectedResult != null)
         {
-            var psi = new System.Diagnostics.ProcessStartInfo(_selectedResult.Path) { UseShellExecute = true };
+            var psi = new System.Diagnostics.ProcessStartInfo(SelectedResult.Path) { UseShellExecute = true };
             System.Diagnostics.Process.Start(psi);
         }
     }


### PR DESCRIPTION
## Summary
- register DocumentIndexer via IIndexer interface in app startup
- initialize DataViewModel color collection to avoid nullability warning
- use generated SelectedResult property in SearchOverlayViewModel

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b349cffefc8326ab1ba99895e9ad29