### PR TITLE
Add document search results grid and preview panel

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -8,6 +8,7 @@ using DocFinder.Domain.Settings;
 using DocFinder.Services;
 using DocFinder.UI.Views;
 using DocFinder.UI.ViewModels;
+using DocFinder.UI.Services;
 using DocFinder.Search;
 using DocFinder.Catalog;
 using DocFinder.Indexing;
@@ -31,6 +32,7 @@ public partial class App
                 new WatcherService(
                     sp.GetRequiredService<ISettingsService>().Current.WatchedRoots,
                     sp.GetRequiredService<IIndexer>()));
+            services.AddSingleton<IDocumentViewService, DocumentViewService>();
             services.AddSingleton<SearchOverlayViewModel>();
             services.AddSingleton<SearchOverlay>();
             services.AddSingleton<SettingsViewModel>();

--- a/src/DocFinder.UI/Converters/FileSizeConverter.cs
+++ b/src/DocFinder.UI/Converters/FileSizeConverter.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace DocFinder.UI.Converters;
+
+public sealed class FileSizeConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is long bytes)
+        {
+            double size = bytes;
+            string[] order = ["B", "KB", "MB", "GB", "TB"];
+            int i = 0;
+            while (size >= 1024 && i < order.Length - 1)
+            {
+                size /= 1024;
+                i++;
+            }
+            return string.Format(culture, "{0:0.#} {1}", size, order[i]);
+        }
+        return value;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
+}

--- a/src/DocFinder.UI/Converters/UtcToLocalConverter.cs
+++ b/src/DocFinder.UI/Converters/UtcToLocalConverter.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace DocFinder.UI.Converters;
+
+public sealed class UtcToLocalConverter : IValueConverter
+{
+    public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is DateTime dt)
+        {
+            return dt.ToLocalTime().ToString(culture);
+        }
+        return value;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
+}

--- a/src/DocFinder.UI/Services/DocumentViewService.cs
+++ b/src/DocFinder.UI/Services/DocumentViewService.cs
@@ -1,0 +1,26 @@
+using System;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using DocFinder.Domain;
+
+namespace DocFinder.UI.Services;
+
+public sealed class DocumentViewService : IDocumentViewService
+{
+    public UIElement GetViewer(SearchHit hit)
+    {
+        var ext = Path.GetExtension(hit.Path).ToLowerInvariant();
+        if (ext == ".pdf")
+        {
+            var browser = new WebBrowser();
+            browser.Navigate(new Uri(hit.Path));
+            return browser;
+        }
+        if (ext == ".doc" || ext == ".docx")
+        {
+            return new TextBlock { Text = "Náhled DOC/DOCX není podporován. Použijte tlačítko Otevřít." };
+        }
+        return new TextBlock { Text = "Náhled není k dispozici." };
+    }
+}

--- a/src/DocFinder.UI/Services/IDocumentViewService.cs
+++ b/src/DocFinder.UI/Services/IDocumentViewService.cs
@@ -1,0 +1,9 @@
+using System.Windows;
+using DocFinder.Domain;
+
+namespace DocFinder.UI.Services;
+
+public interface IDocumentViewService
+{
+    UIElement GetViewer(SearchHit hit);
+}

--- a/src/DocFinder.UI/ViewModels/SearchOverlayViewModel.cs
+++ b/src/DocFinder.UI/ViewModels/SearchOverlayViewModel.cs
@@ -21,7 +21,7 @@ public partial class SearchOverlayViewModel : ObservableObject
     public ObservableCollection<SearchHit> Results { get; } = new();
 
     [ObservableProperty]
-    private SearchHit? _selectedResult;
+    private SearchHit? _selectedDocument;
 
     public SearchOverlayViewModel(ISearchService searchService)
     {
@@ -59,12 +59,18 @@ public partial class SearchOverlayViewModel : ObservableObject
     private Task Search() => RunQueryAsync(Query);
 
     [RelayCommand]
-    private void OpenSelected()
+    private void OpenDocument()
     {
-        if (SelectedResult != null)
+        if (SelectedDocument != null)
         {
-            var psi = new System.Diagnostics.ProcessStartInfo(SelectedResult.Path) { UseShellExecute = true };
+            var psi = new System.Diagnostics.ProcessStartInfo(SelectedDocument.Path) { UseShellExecute = true };
             System.Diagnostics.Process.Start(psi);
         }
+    }
+
+    [RelayCommand]
+    private void FilterByExtension(string extension)
+    {
+        FileTypeFilter = extension;
     }
 }

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -2,7 +2,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    Title="DocFinder" Width="720" Height="420"
+    xmlns:conv="clr-namespace:DocFinder.UI.Converters"
+    Title="DocFinder" Width="900" Height="520"
     WindowStartupLocation="CenterScreen"
     WindowStyle="None"
     WindowCornerPreference="Round"
@@ -10,6 +11,10 @@
     WindowBackdropType="Mica"
     ResizeMode="CanResize"
     ShowInTaskbar="True">
+    <ui:FluentWindow.Resources>
+        <conv:FileSizeConverter x:Key="FileSizeConverter" />
+        <conv:UtcToLocalConverter x:Key="UtcToLocalConverter" />
+    </ui:FluentWindow.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -20,6 +25,7 @@
 
         <Grid Grid.Row="1" Margin="16">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
@@ -94,31 +100,47 @@
                 </ui:Button>
             </Grid>
 
+            <!-- Filter -->
+            <ComboBox x:Name="FilterCombo" Grid.Row="1" Width="150" Margin="0,8,0,8"
+                      SelectionChanged="FilterCombo_SelectionChanged">
+                <ComboBoxItem Content="Vše" Tag="all" IsSelected="True"/>
+                <ComboBoxItem Content="PDF" Tag="pdf"/>
+                <ComboBoxItem Content="DOCX" Tag="docx"/>
+            </ComboBox>
+
             <!-- Results and detail -->
-            <Grid Grid.Row="1">
+            <Grid Grid.Row="2">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="2*"/>
                     <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
-                <ListBox Grid.Column="0" ItemsSource="{Binding Results}" SelectedItem="{Binding SelectedResult}">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel>
-                                <TextBlock Text="{Binding FileName}" FontWeight="Bold"/>
-                                <TextBlock Text="{Binding Snippet}" TextWrapping="Wrap"/>
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
-                <StackPanel Grid.Column="1" Margin="8" DataContext="{Binding SelectedResult}">
-                    <TextBlock Text="{Binding FileName}" FontWeight="Bold"/>
-                    <TextBlock Text="{Binding Path}" TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding Ext}"/>
-                    <TextBlock Text="{Binding SizeBytes}"/>
-                    <TextBlock Text="{Binding CreatedUtc}"/>
-                    <TextBlock Text="{Binding ModifiedUtc}"/>
-                    <Button Content="Otevřít" Command="{Binding DataContext.OpenSelectedCommand, RelativeSource={RelativeSource AncestorType=Grid}}" Margin="0,8,0,0"/>
-                </StackPanel>
+                <ui:DataGrid Grid.Column="0"
+                              ItemsSource="{Binding Results}"
+                              SelectedItem="{Binding SelectedDocument}"
+                              AutoGenerateColumns="False"
+                              CanUserSortColumns="True"
+                              IsReadOnly="True">
+                    <ui:DataGrid.Columns>
+                        <ui:DataGridTextColumn Header="Název" Binding="{Binding Meta[Title]}" />
+                        <ui:DataGridTextColumn Header="Soubor" Binding="{Binding FileName}" />
+                        <ui:DataGridTextColumn Header="Přípona" Binding="{Binding Ext}" />
+                        <ui:DataGridTextColumn Header="Velikost" Binding="{Binding SizeBytes, Converter={StaticResource FileSizeConverter}}" />
+                        <ui:DataGridTextColumn Header="Upraveno" Binding="{Binding ModifiedUtc, Converter={StaticResource UtcToLocalConverter}}" />
+                        <ui:DataGridTextColumn Header="Číslo jednací" Binding="{Binding Meta[CaseNumber]}" />
+                        <ui:DataGridTextColumn Header="Parcelní číslo" Binding="{Binding Meta[ParcelId]}" />
+                    </ui:DataGrid.Columns>
+                </ui:DataGrid>
+
+                <Grid Grid.Column="1" Margin="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Border Grid.Row="0" BorderThickness="1" BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}">
+                        <ContentControl x:Name="PreviewHost" />
+                    </Border>
+                    <Button Grid.Row="1" Content="Otevřít" Command="{Binding OpenDocumentCommand}" Margin="0,8,0,0" />
+                </Grid>
             </Grid>
         </Grid>
     </Grid>


### PR DESCRIPTION
## Summary
- implement results DataGrid with Czech metadata columns and file-type filter
- add document preview panel using DocumentViewService with PDF support and fallback messaging
- integrate commands and DI for opening documents and filtering by extension

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b421a7e3348326b8f57f2b1090b98a