### PR TITLE
Refactor filter control to icon under menu

### DIFF
--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -37,6 +37,10 @@
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
                 <ui:Button
                     x:Name="MenuButton"
                     Width="36"
@@ -78,9 +82,29 @@
                     </ui:Button.ContextMenu>
                 </ui:Button>
 
+                <ui:Button
+                    Grid.Row="1"
+                    Width="36"
+                    Height="36"
+                    Appearance="Secondary"
+                    CornerRadius="8"
+                    ToolTip="Filtry">
+                    <ui:Button.Icon>
+                        <ui:SymbolIcon Symbol="Filter24" />
+                    </ui:Button.Icon>
+                    <ui:Button.ContextMenu>
+                        <ContextMenu>
+                            <MenuItem Header="Vše" Command="{Binding FilterByExtensionCommand}" CommandParameter="all" />
+                            <MenuItem Header="PDF" Command="{Binding FilterByExtensionCommand}" CommandParameter="pdf" />
+                            <MenuItem Header="DOCX" Command="{Binding FilterByExtensionCommand}" CommandParameter="docx" />
+                        </ContextMenu>
+                    </ui:Button.ContextMenu>
+                </ui:Button>
+
                 <ui:TextBox
                     x:Name="QueryTextBox"
                     Grid.Column="1"
+                    Grid.RowSpan="2"
                     Text="{Binding Query, UpdateSourceTrigger=PropertyChanged}"
                     Height="40"
                     Padding="10"
@@ -90,6 +114,7 @@
 
                 <ui:Button
                     Grid.Column="2"
+                    Grid.RowSpan="2"
                     Width="36"
                     Height="36"
                     Appearance="Secondary"
@@ -99,14 +124,6 @@
                     </ui:Button.Icon>
                 </ui:Button>
             </Grid>
-
-            <!-- Filter -->
-            <ComboBox x:Name="FilterCombo" Grid.Row="1" Width="150" Margin="0,8,0,8"
-                      SelectionChanged="FilterCombo_SelectionChanged">
-                <ComboBoxItem Content="Vše" Tag="all" IsSelected="True"/>
-                <ComboBoxItem Content="PDF" Tag="pdf"/>
-                <ComboBoxItem Content="DOCX" Tag="docx"/>
-            </ComboBox>
 
             <!-- Results and detail -->
             <Grid Grid.Row="2">

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml.cs
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml.cs
@@ -102,12 +102,4 @@ public partial class SearchOverlay : FluentWindow
             : null;
     }
 
-    private void FilterCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        if (FilterCombo.SelectedItem is ComboBoxItem item && item.Tag is string tag)
-        {
-            if (_viewModel.FilterByExtensionCommand.CanExecute(tag))
-                _viewModel.FilterByExtensionCommand.Execute(tag);
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- Stack search bar's menu and new filter icon buttons in a two-row left column.
- Replace text filter UI with an icon-only button using `Filter24` and a context menu for file type selection.
- Remove obsolete filter combo event handler.

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b430a19fd883268062e0449b0b1c5f