### PR TITLE
Fix WPF SDK usage and clean up XAML resources

### DIFF
--- a/src/DocFinder.UI/DocFinder.UI.csproj
+++ b/src/DocFinder.UI/DocFinder.UI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>

--- a/src/DocFinder.UI/Resources/DesignTokens.xaml
+++ b/src/DocFinder.UI/Resources/DesignTokens.xaml
@@ -1,5 +1,6 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:System="clr-namespace:System;assembly=mscorlib">
     <!--
         Design tokens for DocFinder UI.
         Spacing values follow the Fluent design 4px ramp and
@@ -13,11 +14,16 @@
     <Thickness x:Key="Space24">24</Thickness>
     <Thickness x:Key="Space32">32</Thickness>
 
+    <!-- Derived margin thicknesses -->
+    <Thickness x:Key="MarginBottomSpace16">0,0,0,16</Thickness>
+    <Thickness x:Key="MarginRightSpace16">0,0,16,0</Thickness>
+    <Thickness x:Key="MarginTopSpace16">0,16,0,0</Thickness>
+
     <!-- Control sizing -->
-    <Double x:Key="ControlHeight">40</Double>
-    <Double x:Key="IconSize">24</Double>
+    <System:Double x:Key="ControlHeight">40</System:Double>
+    <System:Double x:Key="IconSize">24</System:Double>
 
     <!-- Typography -->
-    <Double x:Key="BodyFontSize">14</Double>
-    <Double x:Key="HeaderFontSize">18</Double>
+    <System:Double x:Key="BodyFontSize">14</System:Double>
+    <System:Double x:Key="HeaderFontSize">18</System:Double>
 </ResourceDictionary>

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -60,7 +60,7 @@
             </Style>
         </ResourceDictionary>
     </ui:FluentWindow.Resources>
-    <Grid Background="{DynamicResource SurfaceBackgroundBrush}" Foreground="{DynamicResource TextPrimaryBrush}">
+    <Grid Background="{DynamicResource SurfaceBackgroundBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -75,7 +75,7 @@
             </Grid.RowDefinitions>
 
             <!-- Search bar -->
-            <Grid Grid.Row="0" Margin="0,0,0,{StaticResource Space16}">
+            <Grid Grid.Row="0" Margin="{StaticResource MarginBottomSpace16}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="*"/>
@@ -149,7 +149,7 @@
                     <ColumnDefinition Width="320" x:Name="DetailColumn"/>
                 </Grid.ColumnDefinitions>
 
-                <ui:DataGrid x:Name="ResultsGrid" Grid.Column="0" Margin="0,0,{StaticResource Space16},0"
+                <ui:DataGrid x:Name="ResultsGrid" Grid.Column="0" Margin="{StaticResource MarginRightSpace16}"
                               ItemsSource="{Binding Results}"
                               SelectedItem="{Binding SelectedDocument}"
                               AutoGenerateColumns="False"
@@ -173,7 +173,7 @@
                     <Border Grid.Row="0" BorderThickness="1" BorderBrush="{DynamicResource StrokeBrush}">
                         <ContentControl x:Name="PreviewHost" />
                     </Border>
-                    <ui:Button Grid.Row="1" Content="Otevřít" Command="{Binding OpenDocumentCommand}" Margin="0,{StaticResource Space16},0,0"/>
+                    <ui:Button Grid.Row="1" Content="Otevřít" Command="{Binding OpenDocumentCommand}" Margin="{StaticResource MarginTopSpace16}"/>
                 </Grid>
             </Grid>
         </Grid>


### PR DESCRIPTION
## Summary
- switch UI project to `Microsoft.NET.Sdk`
- clean up XAML: remove Grid foreground and replace invalid margin strings with thickness resources
- define margin and numeric resources and use `System:Double` for numeric tokens

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b43c6de1c48326820c7cd8bde36eb0