### PR TITLE
Fix theme watcher usage and resolve DataGrid conflict

### DIFF
--- a/src/DocFinder.UI/Views/SearchOverlay.xaml.cs
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel;
 using System.Windows;
-using System.Windows.Controls;
+using System.Windows.Media;
 using System.Windows.Media.Animation;
 using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
@@ -31,7 +31,8 @@ public partial class SearchOverlay : FluentWindow
 
         InitializeComponent();
         ApplyTheme(ApplicationThemeManager.GetAppTheme());
-        SystemThemeWatcher.Watch(this, OnThemeChanged);
+        ApplicationThemeManager.Changed += OnThemeChanged;
+        SystemThemeWatcher.Watch(this);
         SizeChanged += SearchOverlay_SizeChanged;
 
         DataContext = _viewModel;
@@ -39,7 +40,7 @@ public partial class SearchOverlay : FluentWindow
         ApplyResponsiveLayout(ActualWidth);
     }
 
-    private void OnThemeChanged(ApplicationTheme newTheme)
+    private void OnThemeChanged(ApplicationTheme newTheme, Color accentColor)
         => ApplyTheme(newTheme);
 
     private void ApplyTheme(ApplicationTheme theme)


### PR DESCRIPTION
## Summary
- listen for ApplicationThemeManager theme changes and watch window without callback
- update theme change handler signature and use WPF UI DataGrid

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b447dac2b08326a231f2bf02018f3a