### PR TITLE
Fix SearchOverlay font resource reference

### DIFF
--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -4,7 +4,7 @@
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:converters="clr-namespace:DocFinder.UI.Converters"
     Title="DocFinder" Width="900" Height="520"
-    FontSize="{StaticResource BodyFontSize}"
+    FontSize="{DynamicResource BodyFontSize}"
     WindowStartupLocation="CenterScreen"
     WindowStyle="None"
     WindowCornerPreference="Round"


### PR DESCRIPTION
## Summary
- use DynamicResource for `BodyFontSize` on SearchOverlay

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b4497f70108326a3c7c6f7afc0b0df