### PR TITLE
Implement robust settings system with defaults and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# DocFinder
+
+This repository contains a WPF application for searching and indexing documents.
+
+## Settings
+
+DocFinder uses a JSON based settings system located in the user's **LocalAppData** folder
+(`%LOCALAPPDATA%/DocFinder/settings.json`).  The defaults are defined in code and are
+applied when no file exists or when new properties are introduced.  This mimics the
+behaviour of .NET application/user settings where application scoped values are read
+only and user scoped values can be modified at runtime.
+
+User settings are only written to disk when `SaveAsync` is called on the settings service.
+If the application exits without calling `SaveAsync`, changes are discarded – similar to
+[`Settings.Save()` in .NET](https://gigi.nullneuron.net/gigilabs/saving-user-preferences-in-wpf/).
+
+New settings added in future versions will automatically fall back to their default
+values when loading older configuration files.

--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -43,11 +43,21 @@ public partial class App
 
     private async void OnStartup(object sender, StartupEventArgs e)
     {
+        // Load user settings before any services are started so that other
+        // services (like the file watcher) receive the correct configuration.
+        var settings = Services.GetRequiredService<ISettingsService>();
+        await settings.LoadAsync();
+
         await _host.StartAsync();
     }
 
     private async void OnExit(object sender, ExitEventArgs e)
     {
+        // Persist user changes.  Like .NET user scoped settings, values are only
+        // written when SaveAsync is called explicitly.
+        var settings = Services.GetRequiredService<ISettingsService>();
+        await settings.SaveAsync(settings.Current);
+
         await _host.StopAsync();
         _host.Dispose();
     }

--- a/src/DocFinder.Domain/Settings/AppSettings.cs
+++ b/src/DocFinder.Domain/Settings/AppSettings.cs
@@ -2,12 +2,35 @@ using System.Collections.Generic;
 
 namespace DocFinder.Domain.Settings;
 
+/// <summary>
+/// Represents user modifiable settings for the application.
+/// Values provided here act as design time defaults.  When the
+/// settings file is missing or new properties are added in future
+/// versions, these defaults are used automatically.
+/// </summary>
 public sealed class AppSettings
 {
+    /// <summary>Optional source folder which is also added to <see cref="WatchedRoots"/> when saved.</summary>
     public string? SourceRoot { get; set; }
+
+    /// <summary>Directories that should be monitored for new documents.</summary>
     public List<string> WatchedRoots { get; set; } = new();
-    public bool EnableOcr { get; set; } = true;
+
+    /// <summary>Whether Optical Character Recognition is enabled.</summary>
+    public bool EnableOcr { get; set; } = false;
+
+    /// <summary>User selected theme.  "Light" and "Dark" are supported.</summary>
+    public string Theme { get; set; } = "Light";
+
+    /// <summary>Automatically re-index all documents on application start.</summary>
+    public bool AutoIndexOnStartup { get; set; } = true;
+
+    /// <summary>Use fuzzy search when querying the index.</summary>
+    public bool UseFuzzySearch { get; set; } = false;
+
+    /// <summary>Frequency in minutes the file system is polled for changes.</summary>
     public int PollingMinutes { get; set; } = 5;
+
     public string? IndexPath { get; set; }
     public string? ThumbsPath { get; set; }
 }

--- a/src/DocFinder.Domain/Settings/ISettingsService.cs
+++ b/src/DocFinder.Domain/Settings/ISettingsService.cs
@@ -6,6 +6,6 @@ namespace DocFinder.Domain.Settings;
 public interface ISettingsService
 {
     AppSettings Current { get; }
-    Task LoadAsync(CancellationToken ct = default);
+    Task<AppSettings> LoadAsync(CancellationToken ct = default);
     Task SaveAsync(AppSettings settings, CancellationToken ct = default);
 }

--- a/src/DocFinder.Indexing/IWatcherService.cs
+++ b/src/DocFinder.Indexing/IWatcherService.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Collections.Generic;
 
 namespace DocFinder.Indexing;
 
 public interface IWatcherService : IDisposable
 {
     void Start();
+    /// <summary>Reconfigure the watcher to monitor a new set of roots.</summary>
+    void UpdateRoots(IEnumerable<string> roots);
 }
 

--- a/src/DocFinder.Indexing/WatcherService.cs
+++ b/src/DocFinder.Indexing/WatcherService.cs
@@ -6,7 +6,7 @@ namespace DocFinder.Indexing;
 
 public sealed class WatcherService : IWatcherService
 {
-    private readonly IEnumerable<string> _roots;
+    private IEnumerable<string> _roots;
     private readonly IIndexer _indexer;
     private readonly List<FileSystemWatcher> _watchers = new();
 
@@ -30,6 +30,18 @@ public sealed class WatcherService : IWatcherService
             watcher.Changed += OnChanged;
             _watchers.Add(watcher);
         }
+    }
+
+    public void UpdateRoots(IEnumerable<string> roots)
+    {
+        _roots = roots;
+        Restart();
+    }
+
+    private void Restart()
+    {
+        Dispose();
+        Start();
     }
 
     private void OnChanged(object sender, FileSystemEventArgs e)

--- a/src/DocFinder.Services/SettingsService.cs
+++ b/src/DocFinder.Services/SettingsService.cs
@@ -17,23 +17,28 @@ public sealed class SettingsService : ISettingsService
 
     public SettingsService(string? filePath = null)
     {
-        _filePath = filePath ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "DocFinder", "settings.json");
+        // Store user settings per user in the local application data folder.
+        _filePath = filePath ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DocFinder", "settings.json");
     }
 
     public AppSettings Current { get; private set; } = new();
 
-    public async Task LoadAsync(CancellationToken ct = default)
+    public async Task<AppSettings> LoadAsync(CancellationToken ct = default)
     {
+        AppSettings? loaded = null;
         if (File.Exists(_filePath))
         {
             await using var stream = File.OpenRead(_filePath);
-            var settings = await JsonSerializer.DeserializeAsync<AppSettings>(stream, _jsonOptions, ct);
-            Current = settings ?? new AppSettings();
+            loaded = await JsonSerializer.DeserializeAsync<AppSettings>(stream, _jsonOptions, ct);
         }
+
+        Current = MergeWithDefaults(loaded);
+        return Current;
     }
 
     public async Task SaveAsync(AppSettings settings, CancellationToken ct = default)
     {
+        // When saving, ensure that SourceRoot is included in the watched list so that it will be monitored next run.
         if (!string.IsNullOrWhiteSpace(settings.SourceRoot) &&
             !settings.WatchedRoots.Contains(settings.SourceRoot, StringComparer.OrdinalIgnoreCase))
         {
@@ -48,6 +53,22 @@ public sealed class SettingsService : ISettingsService
         await JsonSerializer.SerializeAsync(stream, settings, _jsonOptions, ct);
         await stream.FlushAsync(ct);
 
-        Current = settings;
+        Current = MergeWithDefaults(settings);
+    }
+
+    /// <summary>
+    /// Merges a potentially partially populated settings instance with the default
+    /// values defined on <see cref="AppSettings"/>.
+    /// </summary>
+    private static AppSettings MergeWithDefaults(AppSettings? loaded)
+    {
+        var defaults = new AppSettings();
+        if (loaded == null)
+            return defaults;
+
+        loaded.WatchedRoots ??= defaults.WatchedRoots;
+        loaded.Theme ??= defaults.Theme;
+        // For value types we rely on their defaults if they have not been set.
+        return loaded;
     }
 }

--- a/src/DocFinder.Tests/DocumentIndexerTests.cs
+++ b/src/DocFinder.Tests/DocumentIndexerTests.cs
@@ -24,7 +24,7 @@ public class DocumentIndexerTests
             Current = new AppSettings { WatchedRoots = { root } };
         }
         public AppSettings Current { get; }
-        public Task LoadAsync(System.Threading.CancellationToken ct = default) => Task.CompletedTask;
+        public Task<AppSettings> LoadAsync(System.Threading.CancellationToken ct = default) => Task.FromResult(Current);
         public Task SaveAsync(AppSettings settings, System.Threading.CancellationToken ct = default) => Task.CompletedTask;
     }
 

--- a/src/DocFinder.UI/ViewModels/SettingsViewModel.cs
+++ b/src/DocFinder.UI/ViewModels/SettingsViewModel.cs
@@ -2,20 +2,25 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DocFinder.Domain.Settings;
 using DocFinder.Services;
+using DocFinder.Indexing;
 using System.Threading.Tasks;
+using Wpf.Ui.Appearance;
+using System;
 
 namespace DocFinder.UI.ViewModels;
 
 public partial class SettingsViewModel : ObservableObject
 {
     private readonly ISettingsService _settingsService;
+    private readonly IWatcherService _watcherService;
 
     [ObservableProperty]
     private AppSettings _settings = new();
 
-    public SettingsViewModel(ISettingsService settingsService)
+    public SettingsViewModel(ISettingsService settingsService, IWatcherService watcherService)
     {
         _settingsService = settingsService;
+        _watcherService = watcherService;
         _settings = settingsService.Current;
     }
 
@@ -23,5 +28,14 @@ public partial class SettingsViewModel : ObservableObject
     private async Task SaveAsync()
     {
         await _settingsService.SaveAsync(Settings);
+
+        // Restart file watchers to reflect the updated roots
+        _watcherService.UpdateRoots(Settings.WatchedRoots);
+
+        // Apply the selected theme immediately
+        var theme = Settings.Theme.Equals("Dark", StringComparison.OrdinalIgnoreCase)
+            ? ApplicationTheme.Dark
+            : ApplicationTheme.Light;
+        ApplicationThemeManager.Apply(theme);
     }
 }

--- a/src/DocFinder.UI/Views/SettingsWindow.xaml
+++ b/src/DocFinder.UI/Views/SettingsWindow.xaml
@@ -19,6 +19,13 @@
             <TextBlock Text="Source Folder"/>
             <TextBox Text="{Binding Settings.SourceRoot, UpdateSourceTrigger=PropertyChanged}"/>
             <CheckBox Content="Enable OCR" IsChecked="{Binding Settings.EnableOcr}"/>
+            <TextBlock Margin="0,12,0,0" Text="Theme"/>
+            <ComboBox SelectedValue="{Binding Settings.Theme}" SelectedValuePath="Content">
+                <ComboBoxItem Content="Light"/>
+                <ComboBoxItem Content="Dark"/>
+            </ComboBox>
+            <CheckBox Content="Auto index on startup" IsChecked="{Binding Settings.AutoIndexOnStartup}"/>
+            <CheckBox Content="Use fuzzy search" IsChecked="{Binding Settings.UseFuzzySearch}"/>
             <Button Content="Save" Command="{Binding SaveCommand}" Margin="0,20,0,0"/>
         </StackPanel>
     </Grid>

--- a/src/DocFinder.UI/Views/SettingsWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/SettingsWindow.xaml.cs
@@ -1,11 +1,16 @@
 using Wpf.Ui.Controls;
+using DocFinder.UI.ViewModels;
 
 namespace DocFinder.UI.Views;
 
 public partial class SettingsWindow : FluentWindow
 {
-    public SettingsWindow()
+    public SettingsViewModel ViewModel { get; }
+
+    public SettingsWindow(SettingsViewModel viewModel)
     {
+        ViewModel = viewModel;
+        DataContext = viewModel;
         InitializeComponent();
     }
 }


### PR DESCRIPTION
## Summary
- add configurable `AppSettings` with theme and indexing options plus sensible defaults
- implement `SettingsService` that loads and saves JSON in LocalAppData and merges missing values
- update settings UI and view model to allow editing, apply theme, and restart watchers
- load settings on startup and save on exit; document user vs. application settings

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b44d2164d8832692d091164fddc87d