### PR TITLE
feat: add document filtering and sorting

### DIFF
--- a/src/DocFinder.Search/LuceneSearchService.cs
+++ b/src/DocFinder.Search/LuceneSearchService.cs
@@ -47,6 +47,10 @@ public sealed class LuceneSearchService : ISearchService, IDisposable
             new StringField("sha256", doc.Sha256, Field.Store.YES),
             new TextField("content", doc.Content ?? string.Empty, Field.Store.YES)
         };
+        if (!string.IsNullOrEmpty(doc.Author))
+            document.Add(new StringField("author", doc.Author, Field.Store.YES));
+        if (!string.IsNullOrEmpty(doc.Version))
+            document.Add(new StringField("version", doc.Version, Field.Store.YES));
         if (!string.IsNullOrEmpty(doc.CaseNumber))
             document.Add(new StringField("caseNumber", doc.CaseNumber, Field.Store.YES));
         if (!string.IsNullOrEmpty(doc.ParcelId))
@@ -145,6 +149,8 @@ public sealed class LuceneSearchService : ISearchService, IDisposable
                     new DateTime(long.Parse(doc.Get("createdTicks") ?? "0")),
                     new DateTime(long.Parse(doc.Get("modifiedTicks") ?? "0")),
                     doc.Get("sha256") ?? string.Empty,
+                    doc.Get("author"),
+                    doc.Get("version"),
                     scoreDoc.Score,
                     snippet,
                     meta));

--- a/src/DocFinder.Tests/LuceneSearchServiceTests.cs
+++ b/src/DocFinder.Tests/LuceneSearchServiceTests.cs
@@ -15,7 +15,7 @@ public class LuceneSearchServiceTests
     {
         using var service = new LuceneSearchService(new RAMDirectory());
         var id = Guid.NewGuid();
-        await service.IndexAsync(new IndexDocument(id, "/file.pdf", "file.pdf", "pdf", 5, DateTime.UtcNow, DateTime.UtcNow, "hash", "hello world", new Dictionary<string, string>()));
+        await service.IndexAsync(new IndexDocument(id, "/file.pdf", "file.pdf", "pdf", 5, DateTime.UtcNow, DateTime.UtcNow, "hash", null, null, "hello world", new Dictionary<string, string>()));
         var result = await service.QueryAsync(new UserQuery("hello", false, null, null, null));
         Assert.Equal(1, result.Total);
         Assert.Equal(id, result.Hits[0].FileId);
@@ -27,7 +27,7 @@ public class LuceneSearchServiceTests
     {
         using var service = new LuceneSearchService(new RAMDirectory());
         var id = Guid.NewGuid();
-        await service.IndexAsync(new IndexDocument(id, "/file.pdf", "file.pdf", "pdf", 5, DateTime.UtcNow, DateTime.UtcNow, "hash", "hello", new Dictionary<string, string>()));
+        await service.IndexAsync(new IndexDocument(id, "/file.pdf", "file.pdf", "pdf", 5, DateTime.UtcNow, DateTime.UtcNow, "hash", null, null, "hello", new Dictionary<string, string>()));
         var result = await service.QueryAsync(new UserQuery("helo", true, null, null, null));
         Assert.Equal(1, result.Total);
     }
@@ -37,7 +37,7 @@ public class LuceneSearchServiceTests
     {
         using var service = new LuceneSearchService(new RAMDirectory());
         var id = Guid.NewGuid();
-        await service.IndexAsync(new IndexDocument(id, "/file.pdf", "file.pdf", "pdf", 5, DateTime.UtcNow, DateTime.UtcNow, "hash", "Příliš žluťoučký kůň", new Dictionary<string, string>()));
+        await service.IndexAsync(new IndexDocument(id, "/file.pdf", "file.pdf", "pdf", 5, DateTime.UtcNow, DateTime.UtcNow, "hash", null, null, "Příliš žluťoučký kůň", new Dictionary<string, string>()));
         var result = await service.QueryAsync(new UserQuery("prilis zlutoucky kun", false, null, null, null));
         Assert.Equal(1, result.Total);
     }

--- a/src/DocFinder.UI/ViewModels/SearchOverlayViewModel.cs
+++ b/src/DocFinder.UI/ViewModels/SearchOverlayViewModel.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows.Data;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -20,12 +23,35 @@ public partial class SearchOverlayViewModel : ObservableObject
 
     public ObservableCollection<SearchHit> Results { get; } = new();
 
+    public CollectionViewSource ResultsView { get; } = new();
+
     [ObservableProperty]
     private SearchHit? _selectedDocument;
+
+    [ObservableProperty]
+    private DateTime? _fromDate;
+
+    [ObservableProperty]
+    private DateTime? _toDate;
+
+    [ObservableProperty]
+    private string _authorFilter = string.Empty;
+
+    [ObservableProperty]
+    private string _versionFilter = string.Empty;
+
+    [ObservableProperty]
+    private string _sortField = nameof(SearchHit.FileName);
+
+    [ObservableProperty]
+    private bool _sortAscending = true;
 
     public SearchOverlayViewModel(ISearchService searchService)
     {
         _searchService = searchService;
+        ResultsView.Source = Results;
+        ResultsView.Filter += ApplyFilter; // https://learn.microsoft.com/dotnet/desktop/wpf/data/how-to-filter-data-in-a-view
+        UpdateSort(); // https://learn.microsoft.com/dotnet/desktop/wpf/data/how-to-sort-data-in-a-view
     }
 
     partial void OnQueryChanged(string value) => _ = RunQueryAsync(value);
@@ -41,6 +67,7 @@ public partial class SearchOverlayViewModel : ObservableObject
         if (string.IsNullOrWhiteSpace(value))
         {
             Results.Clear();
+            ResultsView.View.Refresh();
             return;
         }
 
@@ -53,6 +80,7 @@ public partial class SearchOverlayViewModel : ObservableObject
         Results.Clear();
         foreach (var hit in result.Hits)
             Results.Add(hit);
+        ResultsView.View.Refresh();
     }
 
     [RelayCommand]
@@ -72,5 +100,54 @@ public partial class SearchOverlayViewModel : ObservableObject
     private void FilterByExtension(string extension)
     {
         FileTypeFilter = extension;
+    }
+
+    private void ApplyFilter(object? sender, FilterEventArgs e)
+    {
+        if (e.Item is not SearchHit hit)
+        {
+            e.Accepted = false;
+            return;
+        }
+        if (FromDate.HasValue && hit.ModifiedUtc < FromDate.Value)
+        {
+            e.Accepted = false;
+            return;
+        }
+        if (ToDate.HasValue && hit.ModifiedUtc > ToDate.Value)
+        {
+            e.Accepted = false;
+            return;
+        }
+        if (!string.IsNullOrWhiteSpace(AuthorFilter) && !string.Equals(hit.Author, AuthorFilter, StringComparison.OrdinalIgnoreCase))
+        {
+            e.Accepted = false;
+            return;
+        }
+        if (!string.IsNullOrWhiteSpace(VersionFilter) && !string.Equals(hit.Version, VersionFilter, StringComparison.OrdinalIgnoreCase))
+        {
+            e.Accepted = false;
+            return;
+        }
+        e.Accepted = true;
+    }
+
+    partial void OnFromDateChanged(DateTime? value) => ResultsView.View.Refresh();
+    partial void OnToDateChanged(DateTime? value) => ResultsView.View.Refresh();
+    partial void OnAuthorFilterChanged(string value) => ResultsView.View.Refresh();
+    partial void OnVersionFilterChanged(string value) => ResultsView.View.Refresh();
+    partial void OnSortFieldChanged(string value) => UpdateSort();
+    partial void OnSortAscendingChanged(bool value) => UpdateSort();
+
+    private void UpdateSort()
+    {
+        var dir = SortAscending ? ListSortDirection.Ascending : ListSortDirection.Descending;
+        var view = ResultsView.View;
+        if (view == null) return;
+        view.SortDescriptions.Clear();
+        var field = SortField == nameof(SearchHit.FileName) ? nameof(SearchHit.SortKey) : SortField;
+        view.SortDescriptions.Add(new SortDescription(field, dir));
+        if (SortField != nameof(SearchHit.FileName))
+            view.SortDescriptions.Add(new SortDescription(nameof(SearchHit.SortKey), ListSortDirection.Ascending));
     }
 }

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -69,10 +69,11 @@
         <ui:TitleBar Grid.Row="0" Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}" />
 
         <Grid Grid.Row="1" Margin="{StaticResource Space24}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
             <!-- Search bar -->
             <Grid Grid.Row="0" Margin="{StaticResource MarginBottomSpace16}">
@@ -142,15 +143,49 @@
                 </ui:Button>
             </Grid>
 
+            <!-- Filter panel -->
+            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="{StaticResource MarginBottomSpace16}">
+                <DatePicker SelectedDate="{Binding FromDate}" Width="150" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" ToolTip="Od"/>
+                <DatePicker SelectedDate="{Binding ToDate}" Width="150" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" ToolTip="Do"/>
+                <ui:TextBox Text="{Binding AuthorFilter, UpdateSourceTrigger=PropertyChanged}" Width="120" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" PlaceholderEnabled="True" PlaceholderText="Autor"/>
+                <ui:TextBox Text="{Binding VersionFilter, UpdateSourceTrigger=PropertyChanged}" Width="100" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" PlaceholderEnabled="True" PlaceholderText="Verze"/>
+                <ComboBox SelectedValuePath="Tag" SelectedValue="{Binding SortField}" Width="140" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}">
+                    <ComboBoxItem Content="Název" Tag="FileName"/>
+                    <ComboBoxItem Content="Změněno" Tag="ModifiedUtc"/>
+                    <ComboBoxItem Content="Autor" Tag="Author"/>
+                    <ComboBoxItem Content="Verze" Tag="Version"/>
+                </ComboBox>
+                <ui:ToggleButton IsChecked="{Binding SortAscending}" Margin="{StaticResource Space8}">
+                    <ui:ToggleButton.Style>
+                        <Style TargetType="ui:ToggleButton" BasedOn="{StaticResource IconButtonStyle}">
+                            <Setter Property="Content">
+                                <Setter.Value>
+                                    <ui:SymbolIcon Symbol="ArrowSortDownLines20" FontSize="{StaticResource IconSize}"/>
+                                </Setter.Value>
+                            </Setter>
+                            <Style.Triggers>
+                                <Trigger Property="IsChecked" Value="True">
+                                    <Setter Property="Content">
+                                        <Setter.Value>
+                                            <ui:SymbolIcon Symbol="ArrowSortUpLines20" FontSize="{StaticResource IconSize}"/>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ui:ToggleButton.Style>
+                </ui:ToggleButton>
+            </StackPanel>
+
             <!-- Results and detail -->
-            <Grid Grid.Row="1">
+            <Grid Grid.Row="2">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" x:Name="ResultsColumn"/>
                     <ColumnDefinition Width="320" x:Name="DetailColumn"/>
                 </Grid.ColumnDefinitions>
 
                 <ui:DataGrid x:Name="ResultsGrid" Grid.Column="0" Margin="{StaticResource MarginRightSpace16}"
-                              ItemsSource="{Binding Results}"
+                              ItemsSource="{Binding ResultsView.View}"
                               SelectedItem="{Binding SelectedDocument}"
                               AutoGenerateColumns="False"
                               CanUserSortColumns="True"
@@ -158,7 +193,9 @@
                               RowStyle="{StaticResource SearchRowStyle}"
                               Loaded="ResultsGrid_Loaded">
                     <ui:DataGrid.Columns>
-                        <DataGridTextColumn Header="Název" Binding="{Binding FileName}" Width="*"/>
+                        <DataGridTextColumn Header="Název" Binding="{Binding FileName}" SortMemberPath="SortKey" Width="*"/>
+                        <DataGridTextColumn Header="Autor" Binding="{Binding Author}" Width="120"/>
+                        <DataGridTextColumn Header="Verze" Binding="{Binding Version}" Width="80"/>
                         <DataGridTextColumn Header="Typ" Binding="{Binding Ext}" Width="80"/>
                         <DataGridTextColumn Header="Velikost" Binding="{Binding SizeBytes, Converter={StaticResource FileSizeConverter}}" Width="100"/>
                         <DataGridTextColumn Header="Změněno" Binding="{Binding ModifiedUtc, Converter={StaticResource UtcToLocalConverter}}" Width="140"/>


### PR DESCRIPTION
## Summary
- extend document records with author, version and culture-insensitive sort key
- extract PDF/DOCX metadata during indexing and expose through search hits
- add CollectionView-based filtering and sorting UI with date, author, version controls

## Testing
- `dotnet build src/DocFinder.Indexing/DocFinder.Indexing.csproj`
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing for UI projects but unit tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68b4652612b4832690aca314172cc98c