### PR TITLE
Fix missing ToggleButton namespace

### DIFF
--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -41,6 +41,25 @@
                 </Style.Triggers>
             </Style>
 
+            <!-- Toggle button style with interaction states -->
+            <Style x:Key="IconToggleButtonStyle" TargetType="ToggleButton" BasedOn="{StaticResource {x:Type ToggleButton}}">
+                <Setter Property="Width" Value="{StaticResource ControlHeight}" />
+                <Setter Property="Height" Value="{StaticResource ControlHeight}" />
+                <Setter Property="Margin" Value="{StaticResource Space4}" />
+                <Setter Property="ToolTipService.ShowOnDisabled" Value="True" />
+                <Style.Triggers>
+                    <Trigger Property="IsMouseOver" Value="True">
+                        <Setter Property="Background" Value="{DynamicResource ControlHoverBrush}" />
+                    </Trigger>
+                    <Trigger Property="IsPressed" Value="True">
+                        <Setter Property="Background" Value="{DynamicResource ControlPressedBrush}" />
+                    </Trigger>
+                    <Trigger Property="IsEnabled" Value="False">
+                        <Setter Property="Foreground" Value="{DynamicResource StrokeBrush}" />
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
+
             <!-- Data grid row style for hover and selection -->
             <Style x:Key="SearchRowStyle" TargetType="DataGridRow">
                 <Setter Property="Height" Value="{StaticResource ControlHeight}" />
@@ -155,9 +174,9 @@
                     <ComboBoxItem Content="Autor" Tag="Author"/>
                     <ComboBoxItem Content="Verze" Tag="Version"/>
                 </ComboBox>
-                <ui:ToggleButton IsChecked="{Binding SortAscending}" Margin="{StaticResource Space8}">
-                    <ui:ToggleButton.Style>
-                        <Style TargetType="ui:ToggleButton" BasedOn="{StaticResource IconButtonStyle}">
+                <ToggleButton IsChecked="{Binding SortAscending}" Margin="{StaticResource Space8}">
+                    <ToggleButton.Style>
+                        <Style TargetType="ToggleButton" BasedOn="{StaticResource IconToggleButtonStyle}">
                             <Setter Property="Content">
                                 <Setter.Value>
                                     <ui:SymbolIcon Symbol="ArrowSortDownLines20" FontSize="{StaticResource IconSize}"/>
@@ -173,8 +192,8 @@
                                 </Trigger>
                             </Style.Triggers>
                         </Style>
-                    </ui:ToggleButton.Style>
-                </ui:ToggleButton>
+                    </ToggleButton.Style>
+                </ToggleButton>
             </StackPanel>
 
             <!-- Results and detail -->


### PR DESCRIPTION
## Summary
- replace unavailable `ui:ToggleButton` with standard `ToggleButton`
- add `IconToggleButtonStyle` for consistent styling and state triggers

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b468e459588326b87d5c2c956cd6e3