### PR TITLE
Configure EF Core with default SQLite provider

### DIFF
--- a/src/DocFinder.Services/DocumentDbContext.cs
+++ b/src/DocFinder.Services/DocumentDbContext.cs
@@ -12,10 +12,23 @@ public class DocumentDbContext : DbContext
 {
     private readonly ILuceneIndexService? _index;
 
+    public DocumentDbContext(ILuceneIndexService? index = null)
+    {
+        _index = index;
+    }
+
     public DocumentDbContext(DbContextOptions<DocumentDbContext> options, ILuceneIndexService? index = null)
         : base(options)
     {
         _index = index;
+    }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        if (!optionsBuilder.IsConfigured)
+        {
+            optionsBuilder.UseSqlite("Data Source=documents.db");
+        }
     }
 
     public DbSet<Document> Documents => Set<Document>();

--- a/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
@@ -24,11 +24,8 @@ public partial class DocumentWindow : Window
     public DocumentWindow()
     {
         InitializeComponent();
-        var options = new DbContextOptionsBuilder<DocumentDbContext>()
-            .UseSqlite("Data Source=documents.db")
-            .Options;
         var index = new LuceneIndexService();
-        _context = new DocumentDbContext(options, index);
+        _context = new DocumentDbContext(index);
         _context.Database.EnsureCreated();
         _documents = new ObservableCollection<Document>(_context.Documents.ToList());
         documentsGrid.ItemsSource = _documents;


### PR DESCRIPTION
## Summary
- Add parameterless constructor and default SQLite configuration in DocumentDbContext
- Simplify DocumentWindow to rely on context's internal configuration

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b48c82a4a48326844d808589943e34