### PR TITLE
Add drag-and-drop file import to document grid

### DIFF
--- a/src/DocFinder.UI/Views/DocumentWindow.xaml
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml
@@ -24,7 +24,8 @@
             </ComboBox>
         </StackPanel>
         <DataGrid x:Name="documentsGrid" AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" IsReadOnly="False"
-                  RowEditEnding="DataGrid_RowEditEnding" PreviewKeyDown="DataGrid_PreviewKeyDown">
+                  RowEditEnding="DataGrid_RowEditEnding" PreviewKeyDown="DataGrid_PreviewKeyDown"
+                  AllowDrop="True" Drop="DocumentsGrid_Drop">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Budova" Binding="{Binding BuildingName}"/>
                 <DataGridTextColumn Header="Název" Binding="{Binding Name}"/>

--- a/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
@@ -88,6 +88,33 @@ public partial class DocumentWindow : Window
         }
     }
 
+    private void DocumentsGrid_Drop(object sender, DragEventArgs e)
+    {
+        if (!e.Data.GetDataPresent(DataFormats.FileDrop)) return;
+        if (e.Data.GetData(DataFormats.FileDrop) is not string[] paths) return;
+        foreach (var path in paths)
+        {
+            if (!File.Exists(path))
+                continue;
+            if (_documents.Any(d => string.Equals(d.FileLink, path, StringComparison.OrdinalIgnoreCase)))
+                continue;
+            var info = new FileInfo(path);
+            var doc = new Document
+            {
+                BuildingName = Path.GetFileName(Path.GetDirectoryName(path) ?? string.Empty),
+                Name = Path.GetFileNameWithoutExtension(path),
+                Author = string.Empty,
+                ModifiedAt = info.LastWriteTime,
+                Version = string.Empty,
+                Type = info.Extension.Trim('.'),
+                FileLink = path
+            };
+            _context.Documents.Add(doc);
+            _documents.Add(doc);
+        }
+        _context.SaveChanges();
+    }
+
     private void FileLink_Click(object sender, MouseButtonEventArgs e)
     {
         if (sender is TextBlock tb && tb.DataContext is Document doc)


### PR DESCRIPTION
## Summary
- allow dropping files onto the document grid to import them automatically
- persist dropped files to the SQLite document database and display in the grid

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b493619d148326b9e9cf8d11b5306e