### PR TITLE
Refactor catalog repository to use EF Core

### DIFF
--- a/src/DocFinder.Catalog/CatalogDbContext.cs
+++ b/src/DocFinder.Catalog/CatalogDbContext.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace DocFinder.Catalog;
+
+public class CatalogDbContext : DbContext
+{
+    public CatalogDbContext(DbContextOptions<CatalogDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<CatalogFile> Files => Set<CatalogFile>();
+    public DbSet<FileMetadata> Metadata => Set<FileMetadata>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<CatalogFile>()
+            .HasKey(f => f.FileId);
+
+        modelBuilder.Entity<FileMetadata>()
+            .HasKey(m => new { m.FileId, m.Key });
+
+        modelBuilder.Entity<FileMetadata>()
+            .HasOne(m => m.File)
+            .WithMany(f => f.Metadata)
+            .HasForeignKey(m => m.FileId);
+    }
+}
+
+public class CatalogFile
+{
+    public Guid FileId { get; set; }
+    public string Path { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
+    public string Ext { get; set; } = string.Empty;
+    public long SizeBytes { get; set; }
+    public DateTime CreatedUtc { get; set; }
+    public DateTime ModifiedUtc { get; set; }
+    public string Sha256 { get; set; } = string.Empty;
+    public ICollection<FileMetadata> Metadata { get; set; } = new List<FileMetadata>();
+}
+
+public class FileMetadata
+{
+    public Guid FileId { get; set; }
+    public CatalogFile File { get; set; } = null!;
+    public string Key { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/DocFinder.Catalog/CatalogRepository.cs
+++ b/src/DocFinder.Catalog/CatalogRepository.cs
@@ -1,122 +1,66 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 using DocFinder.Domain;
 
 namespace DocFinder.Catalog;
 
 public sealed class CatalogRepository
 {
-    private readonly string _connectionString;
+    private readonly DbContextOptions<CatalogDbContext> _options;
 
     public CatalogRepository(string? dbPath = null)
     {
         var path = dbPath ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "DocFinder", "catalog.db");
         var dir = Path.GetDirectoryName(path);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-        _connectionString = $"Data Source={path}";
-        EnsureSchema();
-    }
-
-    private void EnsureSchema()
-    {
-        using var connection = new SqliteConnection(_connectionString);
-        connection.Open();
-        using var cmd = connection.CreateCommand();
-        cmd.CommandText = @"CREATE TABLE IF NOT EXISTS Files(
-            FileId TEXT PRIMARY KEY,
-            Path TEXT NOT NULL,
-            FileName TEXT NOT NULL,
-            Ext TEXT NOT NULL,
-            SizeBytes INTEGER NOT NULL,
-            CreatedUtc TEXT NOT NULL,
-            ModifiedUtc TEXT NOT NULL,
-            Sha256 TEXT NOT NULL
-        );";
-        cmd.ExecuteNonQuery();
-
-        // Ensure SizeBytes column exists for databases created before it was introduced
-        using (var colCmd = connection.CreateCommand())
-        {
-            colCmd.CommandText = "PRAGMA table_info(Files);";
-            using var reader = colCmd.ExecuteReader();
-            var hasSize = false;
-            while (reader.Read())
-            {
-                var name = reader.GetString(1);
-                if (string.Equals(name, "SizeBytes", StringComparison.OrdinalIgnoreCase))
-                {
-                    hasSize = true;
-                    break;
-                }
-            }
-
-            if (!hasSize)
-            {
-                using var alter = connection.CreateCommand();
-                alter.CommandText = "ALTER TABLE Files ADD COLUMN SizeBytes INTEGER NOT NULL DEFAULT 0;";
-                alter.ExecuteNonQuery();
-            }
-        }
-
-        using var meta = connection.CreateCommand();
-        meta.CommandText = @"CREATE TABLE IF NOT EXISTS Metadata(
-            FileId TEXT NOT NULL,
-            Key TEXT NOT NULL,
-            Value TEXT NOT NULL,
-            PRIMARY KEY(FileId,Key)
-        );";
-        meta.ExecuteNonQuery();
+        var connectionString = $"Data Source={path}";
+        _options = new DbContextOptionsBuilder<CatalogDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+        using var db = new CatalogDbContext(_options);
+        db.Database.EnsureCreated();
     }
 
     public async Task UpsertFileAsync(IndexDocument doc, CancellationToken ct = default)
     {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync(ct);
-        await using var tx = await connection.BeginTransactionAsync(ct);
+        await using var db = new CatalogDbContext(_options);
+        var entity = await db.Files.Include(f => f.Metadata)
+            .FirstOrDefaultAsync(f => f.FileId == doc.FileId, ct);
+        if (entity is null)
+        {
+            entity = new CatalogFile { FileId = doc.FileId };
+            db.Files.Add(entity);
+        }
+        else
+        {
+            db.Metadata.RemoveRange(entity.Metadata);
+            entity.Metadata.Clear();
+        }
 
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = @"INSERT OR REPLACE INTO Files(FileId,Path,FileName,Ext,SizeBytes,CreatedUtc,ModifiedUtc,Sha256) VALUES($id,$path,$name,$ext,$size,$created,$mod,$sha);";
-        cmd.Parameters.AddWithValue("$id", doc.FileId.ToString());
-        cmd.Parameters.AddWithValue("$path", doc.Path);
-        cmd.Parameters.AddWithValue("$name", doc.FileName);
-        cmd.Parameters.AddWithValue("$ext", doc.Ext);
-        cmd.Parameters.AddWithValue("$size", doc.SizeBytes);
-        cmd.Parameters.AddWithValue("$created", doc.CreatedUtc.ToString("o"));
-        cmd.Parameters.AddWithValue("$mod", doc.ModifiedUtc.ToString("o"));
-        cmd.Parameters.AddWithValue("$sha", doc.Sha256);
-        await cmd.ExecuteNonQueryAsync(ct);
-
-        var del = connection.CreateCommand();
-        del.CommandText = "DELETE FROM Metadata WHERE FileId=$id";
-        del.Parameters.AddWithValue("$id", doc.FileId.ToString());
-        await del.ExecuteNonQueryAsync(ct);
+        entity.Path = doc.Path;
+        entity.FileName = doc.FileName;
+        entity.Ext = doc.Ext;
+        entity.SizeBytes = doc.SizeBytes;
+        entity.CreatedUtc = doc.CreatedUtc;
+        entity.ModifiedUtc = doc.ModifiedUtc;
+        entity.Sha256 = doc.Sha256;
 
         foreach (var kv in doc.Metadata)
         {
-            var meta = connection.CreateCommand();
-            meta.CommandText = "INSERT INTO Metadata(FileId,Key,Value) VALUES($id,$k,$v)";
-            meta.Parameters.AddWithValue("$id", doc.FileId.ToString());
-            meta.Parameters.AddWithValue("$k", kv.Key);
-            meta.Parameters.AddWithValue("$v", kv.Value);
-            await meta.ExecuteNonQueryAsync(ct);
+            entity.Metadata.Add(new FileMetadata { FileId = doc.FileId, Key = kv.Key, Value = kv.Value });
         }
 
-        await tx.CommitAsync(ct);
+        await db.SaveChangesAsync(ct);
     }
 
     public async Task<DateTime?> GetLastModifiedUtcAsync(string path, CancellationToken ct = default)
     {
-        await using var connection = new SqliteConnection(_connectionString);
-        await connection.OpenAsync(ct);
-        var cmd = connection.CreateCommand();
-        cmd.CommandText = "SELECT ModifiedUtc FROM Files WHERE Path=$p";
-        cmd.Parameters.AddWithValue("$p", path);
-        var result = await cmd.ExecuteScalarAsync(ct) as string;
-        return result != null ? DateTime.Parse(result).ToUniversalTime() : null;
+        await using var db = new CatalogDbContext(_options);
+        var file = await db.Files.AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Path == path, ct);
+        return file?.ModifiedUtc;
     }
 }
-

--- a/src/DocFinder.Catalog/DocFinder.Catalog.csproj
+++ b/src/DocFinder.Catalog/DocFinder.Catalog.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DocFinder.Domain\DocFinder.Domain.csproj" />


### PR DESCRIPTION
## Summary
- add Entity Framework Core context and entity classes for catalog
- refactor `CatalogRepository` to use EF Core for CRUD operations
- update catalog project to reference EF Core

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b544b9fcc8832695270ef94ae7c336