### PR TITLE
Refactor domain entities with validation

### DIFF
--- a/src/DocFinder.Domain/Document.cs
+++ b/src/DocFinder.Domain/Document.cs
@@ -1,31 +1,109 @@
 using System;
-using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace DocFinder.Domain;
 
 public class Document
 {
-    public int Id { get; set; }
-    public string BuildingName { get; set; } = string.Empty;
-    public string Name { get; set; } = string.Empty;
-    public string Author { get; set; } = string.Empty;
-    public DateTime ModifiedAt { get; set; }
-    public string Version { get; set; } = string.Empty;
-    public string Type { get; set; } = string.Empty;
-    public DateTime? IssuedAt { get; set; }
-    public DateTime? ValidUntil { get; set; }
-    public bool CanPrint { get; set; }
-    public bool IsElectronic { get; set; }
-    public string FileLink { get; set; } = string.Empty;
+    private Document() { }
+
+    public Document(
+        int id,
+        string buildingName,
+        string name,
+        string author,
+        DateTime modifiedAt,
+        string version,
+        string type,
+        DateTime? issuedAt,
+        DateTime? validUntil,
+        bool canPrint,
+        bool isElectronic,
+        string fileLink)
+    {
+        Id = id;
+        BuildingName = !string.IsNullOrWhiteSpace(buildingName) ? buildingName : throw new ArgumentException("Building name required", nameof(buildingName));
+        Name = !string.IsNullOrWhiteSpace(name) ? name : throw new ArgumentException("Name required", nameof(name));
+        Author = !string.IsNullOrWhiteSpace(author) ? author : throw new ArgumentException("Author required", nameof(author));
+        ModifiedAt = modifiedAt;
+        Version = version ?? string.Empty;
+        Type = !string.IsNullOrWhiteSpace(type) ? type : throw new ArgumentException("Type required", nameof(type));
+        UpdateValidity(issuedAt, validUntil);
+        CanPrint = canPrint;
+        IsElectronic = isElectronic;
+        FileLink = fileLink ?? string.Empty;
+    }
+
+    public int Id { get; private set; }
+
+    [Required, StringLength(200)]
+    public string BuildingName { get; private set; } = string.Empty;
+
+    [Required, StringLength(200)]
+    public string Name { get; private set; } = string.Empty;
+
+    [Required, StringLength(200)]
+    public string Author { get; private set; } = string.Empty;
+
+    public DateTime ModifiedAt { get; private set; }
+
+    [StringLength(50)]
+    public string Version { get; private set; } = string.Empty;
+
+    [Required, StringLength(50)]
+    public string Type { get; private set; } = string.Empty;
+
+    public DateTime? IssuedAt { get; private set; }
+
+    public DateTime? ValidUntil { get; private set; }
+
+    public bool CanPrint { get; private set; }
+
+    public bool IsElectronic { get; private set; }
+
+    [Url]
+    public string FileLink { get; private set; } = string.Empty;
+
+    public void UpdateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name cannot be empty", nameof(name));
+        Name = name;
+    }
+
+    public void UpdateValidity(DateTime? issuedAt, DateTime? validUntil)
+    {
+        if (issuedAt.HasValue && validUntil.HasValue && validUntil < issuedAt)
+            throw new ArgumentException("ValidUntil must be after IssuedAt", nameof(validUntil));
+        IssuedAt = issuedAt;
+        ValidUntil = validUntil;
+    }
 }
 
 public class AuditEntry
 {
-    public int Id { get; set; }
-    public int DocumentId { get; set; }
-    public string Action { get; set; } = string.Empty;
-    public DateTime Timestamp { get; set; }
-    public string UserName { get; set; } = string.Empty;
+    private AuditEntry() { }
+
+    public AuditEntry(int documentId, string action, DateTime timestamp, string userName)
+    {
+        DocumentId = documentId;
+        Action = !string.IsNullOrWhiteSpace(action) ? action : throw new ArgumentException("Action required", nameof(action));
+        Timestamp = timestamp;
+        UserName = !string.IsNullOrWhiteSpace(userName) ? userName : throw new ArgumentException("User name required", nameof(userName));
+    }
+
+    public int Id { get; private set; }
+
+    public int DocumentId { get; private set; }
+
+    [Required]
+    public string Action { get; private set; } = string.Empty;
+
+    [Required]
+    public DateTime Timestamp { get; private set; }
+
+    [Required, StringLength(100)]
+    public string UserName { get; private set; } = string.Empty;
 }
 
 public interface ILuceneIndexService

--- a/src/DocFinder.Search/LuceneIndexService.cs
+++ b/src/DocFinder.Search/LuceneIndexService.cs
@@ -66,15 +66,19 @@ public sealed class LuceneIndexService : ILuceneIndexService, IDisposable
             foreach (var hit in hits)
             {
                 var d = searcher.Doc(hit.Doc);
-                yield return new DocFinder.Domain.Document
-                {
-                    Id = int.Parse(d.Get("id")),
-                    BuildingName = d.Get("building"),
-                    Name = d.Get("name"),
-                    Author = d.Get("author"),
-                    Type = d.Get("type"),
-                    FileLink = d.Get("fileLink")
-                };
+                yield return new DocFinder.Domain.Document(
+                    id: int.Parse(d.Get("id")),
+                    buildingName: d.Get("building"),
+                    name: d.Get("name"),
+                    author: d.Get("author"),
+                    modifiedAt: DateTime.MinValue,
+                    version: string.Empty,
+                    type: d.Get("type"),
+                    issuedAt: null,
+                    validUntil: null,
+                    canPrint: false,
+                    isElectronic: false,
+                    fileLink: d.Get("fileLink"));
             }
         }
         finally

--- a/src/DocFinder.Services/DocumentDbContext.cs
+++ b/src/DocFinder.Services/DocumentDbContext.cs
@@ -74,13 +74,9 @@ public class DocumentDbContext : DbContext
     private void PostSave(List<(Document doc, string action)> changes)
     {
         if (changes.Count == 0) return;
-        var audits = changes.Select(c => new AuditEntry
-        {
-            DocumentId = c.doc.Id,
-            Action = c.action,
-            Timestamp = DateTime.UtcNow,
-            UserName = Environment.UserName
-        }).ToList();
+        var audits = changes
+            .Select(c => new AuditEntry(c.doc.Id, c.action, DateTime.UtcNow, Environment.UserName))
+            .ToList();
         AuditEntries.AddRange(audits);
         base.SaveChanges();
         if (_index != null)
@@ -98,13 +94,9 @@ public class DocumentDbContext : DbContext
     private async Task PostSaveAsync(List<(Document doc, string action)> changes, CancellationToken ct)
     {
         if (changes.Count == 0) return;
-        var audits = changes.Select(c => new AuditEntry
-        {
-            DocumentId = c.doc.Id,
-            Action = c.action,
-            Timestamp = DateTime.UtcNow,
-            UserName = Environment.UserName
-        }).ToList();
+        var audits = changes
+            .Select(c => new AuditEntry(c.doc.Id, c.action, DateTime.UtcNow, Environment.UserName))
+            .ToList();
         await AuditEntries.AddRangeAsync(audits, ct);
         await base.SaveChangesAsync(ct);
         if (_index != null)

--- a/src/DocFinder.Tests/DocumentDbContextTests.cs
+++ b/src/DocFinder.Tests/DocumentDbContextTests.cs
@@ -32,16 +32,19 @@ public class DocumentDbContextTests
         using var ctx = new DocumentDbContext(options, index);
         ctx.Database.EnsureCreated();
 
-        var doc = new Document
-        {
-            BuildingName = "A",
-            Name = "Doc",
-            Author = "Auth",
-            ModifiedAt = DateTime.UtcNow,
-            Version = "1.0",
-            Type = "txt",
-            FileLink = "test.txt"
-        };
+        var doc = new Document(
+            id: 0,
+            buildingName: "A",
+            name: "Doc",
+            author: "Auth",
+            modifiedAt: DateTime.UtcNow,
+            version: "1.0",
+            type: "txt",
+            issuedAt: null,
+            validUntil: null,
+            canPrint: false,
+            isElectronic: false,
+            fileLink: "test.txt");
         ctx.Documents.Add(doc);
         ctx.SaveChanges();
 
@@ -49,7 +52,7 @@ public class DocumentDbContextTests
         Assert.Equal("Insert", ctx.AuditEntries.First().Action);
         Assert.Contains(doc.Id, index.Indexed);
 
-        doc.Name = "Doc2";
+        doc.UpdateName("Doc2");
         ctx.SaveChanges();
         Assert.Equal(2, ctx.AuditEntries.Count());
         Assert.Equal("Update", ctx.AuditEntries.OrderBy(a => a.Id).Last().Action);

--- a/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
@@ -99,16 +99,19 @@ public partial class DocumentWindow : Window
             if (_documents.Any(d => string.Equals(d.FileLink, path, StringComparison.OrdinalIgnoreCase)))
                 continue;
             var info = new FileInfo(path);
-            var doc = new Document
-            {
-                BuildingName = Path.GetFileName(Path.GetDirectoryName(path) ?? string.Empty),
-                Name = Path.GetFileNameWithoutExtension(path),
-                Author = string.Empty,
-                ModifiedAt = info.LastWriteTime,
-                Version = string.Empty,
-                Type = info.Extension.Trim('.'),
-                FileLink = path
-            };
+            var doc = new Document(
+                id: 0,
+                buildingName: Path.GetFileName(Path.GetDirectoryName(path) ?? string.Empty),
+                name: Path.GetFileNameWithoutExtension(path),
+                author: string.Empty,
+                modifiedAt: info.LastWriteTime,
+                version: string.Empty,
+                type: info.Extension.Trim('.'),
+                issuedAt: null,
+                validUntil: null,
+                canPrint: false,
+                isElectronic: false,
+                fileLink: path);
             _context.Documents.Add(doc);
             _documents.Add(doc);
         }


### PR DESCRIPTION
## Summary
- convert `Document` and `AuditEntry` into rich entities with constructors, private setters, and validation attributes
- enforce domain invariants via `UpdateName` and `UpdateValidity`
- adjust persistence, search, UI and tests to use the new entity APIs

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b5498635d4832692d5d8c305021e1a