### PR TITLE
Introduce application-level document indexing abstraction

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -29,6 +29,8 @@ public partial class App
             services.AddSingleton<ITrayService, TrayService>();
             services.AddSingleton<ISettingsService, SettingsService>();
             services.AddSingleton<ISearchService, LuceneSearchService>();
+            services.AddSingleton<ILuceneIndexService, LuceneIndexService>();
+            services.AddSingleton<IDocumentIndexService, DocumentIndexService>();
             services.AddSingleton<CatalogRepository>();
             services.AddSingleton<IIndexer, DocumentIndexer>();
             services.AddSingleton<CommandDispatcher>();

--- a/src/DocFinder.Application/DocumentIndexService.cs
+++ b/src/DocFinder.Application/DocumentIndexService.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using DocFinder.Domain;
+using DocFinder.Search;
+
+namespace DocFinder.Application;
+
+public sealed class DocumentIndexService : IDocumentIndexService
+{
+    private readonly ILuceneIndexService _inner;
+
+    public DocumentIndexService(ILuceneIndexService inner)
+    {
+        _inner = inner;
+    }
+
+    public void IndexDocument(Document doc) => _inner.IndexDocument(doc);
+
+    public void DeleteDocument(int docId) => _inner.DeleteDocument(docId);
+
+    public IEnumerable<Document> Search(string query) => _inner.Search(query);
+}

--- a/src/DocFinder.Application/IDocumentIndexService.cs
+++ b/src/DocFinder.Application/IDocumentIndexService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using DocFinder.Domain;
+
+namespace DocFinder.Application;
+
+public interface IDocumentIndexService
+{
+    void IndexDocument(Document doc);
+    void DeleteDocument(int docId);
+    IEnumerable<Document> Search(string query);
+}

--- a/src/DocFinder.Domain/Document.cs
+++ b/src/DocFinder.Domain/Document.cs
@@ -105,10 +105,3 @@ public class AuditEntry
     [Required, StringLength(100)]
     public string UserName { get; private set; } = string.Empty;
 }
-
-public interface ILuceneIndexService
-{
-    void IndexDocument(Document doc);
-    void DeleteDocument(int docId);
-    IEnumerable<Document> Search(string query);
-}

--- a/src/DocFinder.Search/ILuceneIndexService.cs
+++ b/src/DocFinder.Search/ILuceneIndexService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using DocFinder.Domain;
+
+namespace DocFinder.Search;
+
+public interface ILuceneIndexService
+{
+    void IndexDocument(Document doc);
+    void DeleteDocument(int docId);
+    IEnumerable<Document> Search(string query);
+}

--- a/src/DocFinder.Services/DocFinder.Services.csproj
+++ b/src/DocFinder.Services/DocFinder.Services.csproj
@@ -22,5 +22,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DocFinder.Domain\DocFinder.Domain.csproj" />
+    <ProjectReference Include="..\DocFinder.Application\DocFinder.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/DocFinder.Services/DocumentDbContext.cs
+++ b/src/DocFinder.Services/DocumentDbContext.cs
@@ -4,20 +4,21 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DocFinder.Domain;
+using DocFinder.Application;
 using Microsoft.EntityFrameworkCore;
 
 namespace DocFinder.Services;
 
 public class DocumentDbContext : DbContext
 {
-    private readonly ILuceneIndexService? _index;
+    private readonly IDocumentIndexService? _index;
 
-    public DocumentDbContext(ILuceneIndexService? index = null)
+    public DocumentDbContext(IDocumentIndexService? index = null)
     {
         _index = index;
     }
 
-    public DocumentDbContext(DbContextOptions<DocumentDbContext> options, ILuceneIndexService? index = null)
+    public DocumentDbContext(DbContextOptions<DocumentDbContext> options, IDocumentIndexService? index = null)
         : base(options)
     {
         _index = index;

--- a/src/DocFinder.Tests/DocFinder.Tests.csproj
+++ b/src/DocFinder.Tests/DocFinder.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\DocFinder.Search\DocFinder.Search.csproj" />
     <ProjectReference Include="..\DocFinder.Catalog\DocFinder.Catalog.csproj" />
     <ProjectReference Include="..\DocFinder.Indexing\DocFinder.Indexing.csproj" />
+    <ProjectReference Include="..\DocFinder.Application\DocFinder.Application.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/DocFinder.Tests/DocumentDbContextTests.cs
+++ b/src/DocFinder.Tests/DocumentDbContextTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DocFinder.Domain;
 using DocFinder.Services;
+using DocFinder.Application;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -11,7 +12,7 @@ namespace DocFinder.Tests;
 
 public class DocumentDbContextTests
 {
-    private sealed class StubIndex : ILuceneIndexService
+    private sealed class StubIndex : IDocumentIndexService
     {
         public List<int> Indexed { get; } = new();
         public List<int> Deleted { get; } = new();

--- a/src/DocFinder.UI/DocFinder.UI.csproj
+++ b/src/DocFinder.UI/DocFinder.UI.csproj
@@ -15,5 +15,6 @@
     <ProjectReference Include="..\DocFinder.Search\DocFinder.Search.csproj" />
     <ProjectReference Include="..\DocFinder.Services\DocFinder.Services.csproj" />
     <ProjectReference Include="..\DocFinder.Indexing\DocFinder.Indexing.csproj" />
+    <ProjectReference Include="..\DocFinder.Application\DocFinder.Application.csproj" />
   </ItemGroup>
 </Project>

--- a/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Input;
 using DocFinder.Domain;
 using DocFinder.Services;
 using DocFinder.Search;
+using DocFinder.Application;
 using Microsoft.EntityFrameworkCore;
 
 namespace DocFinder.UI.Views;
@@ -28,7 +29,8 @@ public partial class DocumentWindow : Window
     public DocumentWindow(DbContextOptions<DocumentDbContext>? dbOptions)
     {
         InitializeComponent();
-        var index = new LuceneIndexService();
+        var lucene = new LuceneIndexService();
+        IDocumentIndexService index = new DocumentIndexService(lucene);
         _context = dbOptions != null
             ? new DocumentDbContext(dbOptions, index)
             : new DocumentDbContext(index);


### PR DESCRIPTION
## Summary
- Move Lucene index interface into DocFinder.Search
- Add application-layer `IDocumentIndexService` wrapper
- Inject index service into `DocumentDbContext` and register via DI

## Testing
- `~/.dotnet/dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b55a754dc08326b4ee3aa80b646a73