### PR TITLE
Implement asynchronous file watcher processing

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using DocFinder.Domain;
 using DocFinder.Domain.Settings;
 using DocFinder.Services;
@@ -38,7 +39,8 @@ public partial class App
             services.AddSingleton<IWatcherService>(sp =>
                 new WatcherService(
                     sp.GetRequiredService<ISettingsService>().Current.WatchedRoots,
-                    sp.GetRequiredService<IIndexer>()));
+                    sp.GetRequiredService<IIndexer>(),
+                    sp.GetRequiredService<ILogger<WatcherService>>()));
             services.AddSingleton<IDocumentViewService, DocumentViewService>();
             services.AddSingleton<SearchOverlayViewModel>();
             services.AddSingleton<SearchOverlay>();

--- a/src/DocFinder.App/Services/ApplicationHostService.cs
+++ b/src/DocFinder.App/Services/ApplicationHostService.cs
@@ -40,7 +40,7 @@ public class ApplicationHostService : IHostedService
     public Task StopAsync(CancellationToken cancellationToken)
     {
         _tray.Dispose();
-        _watcher.Dispose();
+        _watcher.Stop();
         return Task.CompletedTask;
     }
 }

--- a/src/DocFinder.Indexing/IWatcherService.cs
+++ b/src/DocFinder.Indexing/IWatcherService.cs
@@ -6,6 +6,7 @@ namespace DocFinder.Indexing;
 public interface IWatcherService : IDisposable
 {
     void Start();
+    void Stop();
     /// <summary>Reconfigure the watcher to monitor a new set of roots.</summary>
     void UpdateRoots(IEnumerable<string> roots);
 }


### PR DESCRIPTION
## Summary
- add `Stop` method to watcher service interface and implementation
- process file watcher events via channel with background worker
- log indexing failures and inject logger into watcher service

## Testing
- `~/.dotnet/dotnet test -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_68b55a7787a08326853829abc383aff0