### PR TITLE
Enable pluggable document content extractors

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -30,6 +30,8 @@ public partial class App
             services.AddSingleton<ISettingsService, SettingsService>();
             services.AddSingleton<ISearchService, LuceneSearchService>();
             services.AddSingleton<CatalogRepository>();
+            services.AddSingleton<IContentExtractor, PdfContentExtractor>();
+            services.AddSingleton<IContentExtractor, DocxContentExtractor>();
             services.AddSingleton<IIndexer, DocumentIndexer>();
             services.AddSingleton<CommandDispatcher>();
             services.AddTransient<ICommandHandler<SearchDocumentsCommand, SearchResult>, SearchDocumentsHandler>();

--- a/src/DocFinder.Indexing/DocxContentExtractor.cs
+++ b/src/DocFinder.Indexing/DocxContentExtractor.cs
@@ -1,0 +1,22 @@
+using DocumentFormat.OpenXml.Packaging;
+
+namespace DocFinder.Indexing;
+
+public sealed class DocxContentExtractor : IContentExtractor
+{
+    public bool CanHandle(string extension) => extension.Equals("docx", StringComparison.OrdinalIgnoreCase);
+
+    public Task<ExtractedContent> ExtractAsync(string path, CancellationToken ct)
+    {
+        return Task.Run(() =>
+        {
+            using var doc = WordprocessingDocument.Open(path, false);
+            var text = doc.MainDocumentPart?.Document?.InnerText ?? string.Empty;
+            var props = doc.PackageProperties;
+            DateTimeOffset? created = props.Created.HasValue ? new DateTimeOffset(props.Created.Value).ToUniversalTime() : null;
+            DateTimeOffset? modified = props.Modified.HasValue ? new DateTimeOffset(props.Modified.Value).ToUniversalTime() : null;
+            var version = props.Version ?? props.Revision;
+            return new ExtractedContent(text, props.Creator, version, created, modified);
+        }, ct);
+    }
+}

--- a/src/DocFinder.Indexing/ExtractedContent.cs
+++ b/src/DocFinder.Indexing/ExtractedContent.cs
@@ -1,0 +1,8 @@
+namespace DocFinder.Indexing;
+
+public record ExtractedContent(
+    string Content,
+    string? Author,
+    string? Version,
+    DateTimeOffset? Created,
+    DateTimeOffset? Modified);

--- a/src/DocFinder.Indexing/IContentExtractor.cs
+++ b/src/DocFinder.Indexing/IContentExtractor.cs
@@ -1,0 +1,7 @@
+namespace DocFinder.Indexing;
+
+public interface IContentExtractor
+{
+    bool CanHandle(string extension);
+    Task<ExtractedContent> ExtractAsync(string path, CancellationToken ct);
+}

--- a/src/DocFinder.Indexing/PdfContentExtractor.cs
+++ b/src/DocFinder.Indexing/PdfContentExtractor.cs
@@ -1,0 +1,27 @@
+using System.Text;
+using UglyToad.PdfPig;
+
+namespace DocFinder.Indexing;
+
+public sealed class PdfContentExtractor : IContentExtractor
+{
+    public bool CanHandle(string extension) => extension.Equals("pdf", StringComparison.OrdinalIgnoreCase);
+
+    public Task<ExtractedContent> ExtractAsync(string path, CancellationToken ct)
+    {
+        return Task.Run(() =>
+        {
+            using var pdf = PdfDocument.Open(path);
+            var sb = new StringBuilder();
+            foreach (var page in pdf.GetPages())
+            {
+                ct.ThrowIfCancellationRequested();
+                sb.AppendLine(page.Text);
+            }
+            var info = pdf.Information;
+            DateTimeOffset? created = DateTimeOffset.TryParse(info.CreationDate, out var c) ? c.ToUniversalTime() : null;
+            DateTimeOffset? modified = DateTimeOffset.TryParse(info.ModifiedDate, out var m) ? m.ToUniversalTime() : null;
+            return new ExtractedContent(sb.ToString(), info.Author, pdf.Version.ToString(), created, modified);
+        }, ct);
+    }
+}

--- a/src/DocFinder.Tests/DocumentIndexerTests.cs
+++ b/src/DocFinder.Tests/DocumentIndexerTests.cs
@@ -45,7 +45,12 @@ public class DocumentIndexerTests
         var settings = new FakeSettingsService(temp);
         var catalog = new CatalogRepository(Path.Combine(temp, "catalog.db"));
         using var search = new LuceneSearchService(new RAMDirectory());
-        var indexer = new DocumentIndexer(search, catalog, settings);
+        var extractors = new IContentExtractor[]
+        {
+            new DocxContentExtractor(),
+            new PdfContentExtractor()
+        };
+        var indexer = new DocumentIndexer(search, catalog, settings, extractors);
         await indexer.IndexFileAsync(file);
 
         await using var connection = new SqliteConnection($"Data Source={Path.Combine(temp, "catalog.db")}");


### PR DESCRIPTION
## Summary
- add `IContentExtractor` interface and `ExtractedContent` record
- move PDF and DOCX parsing into dedicated extractors
- refactor `DocumentIndexer` to use registered extractors

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b55a78915c83269eaf50774ccec47e