### PR TITLE
Use StringBuilder for token removal and add query parser tests

### DIFF
--- a/src/DocFinder.Search/UserQueryParser.cs
+++ b/src/DocFinder.Search/UserQueryParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.RegularExpressions;
 using DocFinder.Domain;
 
@@ -14,7 +15,8 @@ public static class UserQueryParser
         var filters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         DateTimeOffset? from = null;
         DateTimeOffset? to = null;
-        var text = input;
+        var sb = new StringBuilder();
+        var lastIndex = 0;
 
         foreach (Match match in _tokenRegex.Matches(input))
         {
@@ -35,10 +37,13 @@ public static class UserQueryParser
                     break;
             }
 
-            text = text.Replace(match.Value, string.Empty);
+            sb.Append(input, lastIndex, match.Index - lastIndex);
+            lastIndex = match.Index + match.Length;
         }
 
-        var free = text.Trim();
+        sb.Append(input, lastIndex, input.Length - lastIndex);
+        var free = sb.ToString().Trim();
+
         return new UserQuery(free)
         {
             Filters = filters,

--- a/src/DocFinder.Tests/QueryParserTests.cs
+++ b/src/DocFinder.Tests/QueryParserTests.cs
@@ -16,4 +16,21 @@ public class QueryParserTests
         Assert.Equal(new DateTimeOffset(2023,1,1,0,0,0,TimeSpan.Zero), query.FromUtc);
         Assert.Null(query.ToUtc);
     }
+
+    [Fact]
+    public void UsesLastValueForDuplicateTokens()
+    {
+        var query = UserQueryParser.Parse("summary type:pdf type:doc");
+        Assert.Equal("summary", query.FreeText);
+        Assert.Equal("doc", query.Filters["type"]);
+    }
+
+    [Fact]
+    public void HandlesMixedQuotedFreeTextAndFilters()
+    {
+        var query = UserQueryParser.Parse("\"exact phrase\" author:\"John Doe\" type:pdf");
+        Assert.Equal("\"exact phrase\"", query.FreeText);
+        Assert.Equal("John Doe", query.Filters["author"]);
+        Assert.Equal("pdf", query.Filters["type"]);
+    }
 }


### PR DESCRIPTION
## Summary
- build remaining free text using StringBuilder and token indices instead of string.Replace
- add tests for duplicate tokens and mixed quoted text

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b55a78dfd08326ba2f99e23e53137f