### PR TITLE
Handle cancellation and file access errors in reindexing

### DIFF
--- a/src/DocFinder.Indexing/IIndexer.cs
+++ b/src/DocFinder.Indexing/IIndexer.cs
@@ -12,7 +12,7 @@ public enum IndexingState
 public interface IIndexer
 {
     Task IndexFileAsync(string path, CancellationToken ct = default);
-    Task ReindexAllAsync();
+    Task ReindexAllAsync(CancellationToken ct = default);
     void Pause();
     void Resume();
     IndexingState State { get; }


### PR DESCRIPTION
## Summary
- allow cancelling reindex operation and propagate token to file indexing
- handle UnauthorizedAccessException and IOException while enumerating and indexing files

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b574b749a4832686a0a7da00a0c3c3