### PR TITLE
Refactor SHA256 computation error handling

### DIFF
--- a/src/DocFinder.Indexing/DocumentIndexer.cs
+++ b/src/DocFinder.Indexing/DocumentIndexer.cs
@@ -139,11 +139,7 @@ public sealed class DocumentIndexer : IIndexer
             var hash = SHA256.HashData(stream);
             return Convert.ToHexString(hash);
         }
-        catch (IOException ex)
-        {
-            Console.Error.WriteLine($"Failed to compute SHA256 for {path}: {ex.Message}");
-        }
-        catch (UnauthorizedAccessException ex)
+        catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
         {
             Console.Error.WriteLine($"Failed to compute SHA256 for {path}: {ex.Message}");
         }


### PR DESCRIPTION
## Summary
- simplify SHA256 calculation error handling by using a combined catch block for IO and access errors

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b57923db6083268b54f2b432ab614b