### PR TITLE
Refactor DbContext configuration to rely on DI

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
 using DocFinder.Domain;
 using DocFinder.Domain.Settings;
 using DocFinder.Services;
@@ -31,6 +32,14 @@ public partial class App
             services.AddSingleton<ISettingsService, SettingsService>();
             services.AddSingleton<ISearchService, LuceneSearchService>();
             services.AddSingleton<ILuceneIndexService, LuceneIndexService>();
+            services.AddScoped<DocumentSaveChangesInterceptor>();
+            services.AddDbContextFactory<DocumentDbContext>(o =>
+                o.UseSqlite("Data Source=documents.db"));
+            services.AddDbContext<DocumentDbContext>((sp, o) =>
+            {
+                o.UseSqlite("Data Source=documents.db");
+                o.AddInterceptors(sp.GetRequiredService<DocumentSaveChangesInterceptor>());
+            });
             services.AddSingleton<IDocumentIndexService, DocumentIndexService>();
             services.AddSingleton<CatalogRepository>();
             services.AddSingleton<IContentExtractor, PdfContentExtractor>();

--- a/src/DocFinder.Services/DocumentDbContext.cs
+++ b/src/DocFinder.Services/DocumentDbContext.cs
@@ -1,24 +1,17 @@
 using DocFinder.Domain;
-using DocFinder.Search;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 
 namespace DocFinder.Services;
 
 public class DocumentDbContext : DbContext
 {
-    private readonly ILuceneIndexService? _index;
-
-    public DocumentDbContext(ILuceneIndexService? index = null)
+    public DocumentDbContext()
     {
-        _index = index;
     }
 
-    public DocumentDbContext(DbContextOptions<DocumentDbContext> options, ILuceneIndexService? index = null)
+    public DocumentDbContext(DbContextOptions<DocumentDbContext> options)
         : base(options)
     {
-        _index = index;
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -27,43 +20,8 @@ public class DocumentDbContext : DbContext
         {
             optionsBuilder.UseSqlite("Data Source=documents.db");
         }
-
-        // Ensure the options are strongly typed to DocumentDbContext. When the context
-        // is constructed using the parameterless constructor (e.g. design-time tools),
-        // optionsBuilder is non-generic and its Options property is untyped. Attempting
-        // to cast in that scenario causes an invalid cast exception. Instead, use the
-        // typed options when available or create a new typed builder.
-        var sqliteExt = optionsBuilder.Options.FindExtension<SqliteOptionsExtension>();
-        var builder = new DbContextOptionsBuilder<DocumentDbContext>();
-        if (sqliteExt?.Connection != null)
-        {
-            builder.UseSqlite(sqliteExt.Connection);
-        }
-        else if (!string.IsNullOrEmpty(sqliteExt?.ConnectionString))
-        {
-            builder.UseSqlite(sqliteExt.ConnectionString!);
-        }
-        else
-        {
-            builder.UseSqlite("Data Source=documents.db");
-        }
-
-        var factory = new SimpleFactory(builder.Options, _index);
-        optionsBuilder.AddInterceptors(new DocumentSaveChangesInterceptor(factory, _index));
     }
 
     public DbSet<Document> Documents => Set<Document>();
     public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
-
-    private sealed class SimpleFactory : IDbContextFactory<DocumentDbContext>
-    {
-        private readonly DbContextOptions<DocumentDbContext> _options;
-        private readonly ILuceneIndexService? _index;
-        public SimpleFactory(DbContextOptions<DocumentDbContext> options, ILuceneIndexService? index)
-        {
-            _options = options;
-            _index = index;
-        }
-        public DocumentDbContext CreateDbContext() => new DocumentDbContext(_options, _index);
-    }
 }

--- a/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
@@ -28,10 +28,9 @@ public partial class DocumentWindow : Window
     public DocumentWindow(DbContextOptions<DocumentDbContext>? dbOptions)
     {
         InitializeComponent();
-        var lucene = new LuceneIndexService();
         _context = dbOptions != null
-            ? new DocumentDbContext(dbOptions, lucene)
-            : new DocumentDbContext(lucene);
+            ? new DocumentDbContext(dbOptions)
+            : new DocumentDbContext();
         _context.Database.EnsureCreated();
         _documents = new ObservableCollection<Document>(_context.Documents.ToList());
         documentsGrid.ItemsSource = _documents;


### PR DESCRIPTION
## Summary
- Configure DocumentDbContext via AddDbContext and register DocumentSaveChangesInterceptor through DI
- Simplify DocumentDbContext to only fallback configuration
- Update tests and UI window for new DbContext signature

## Testing
- `dotnet build src/DocFinder.Tests/DocFinder.Tests.csproj`
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj --no-build` *(hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68b5964a87348326aa6c02c248a35e2e