### PR TITLE
Centralize default DB connection string

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -34,10 +34,10 @@ public partial class App
             services.AddSingleton<ILuceneIndexService, LuceneIndexService>();
             services.AddScoped<DocumentSaveChangesInterceptor>();
             services.AddDbContextFactory<DocumentDbContext>(o =>
-                o.UseSqlite("Data Source=documents.db"));
+                o.UseSqlite(DocumentDbContext.DefaultConnectionString));
             services.AddDbContext<DocumentDbContext>((sp, o) =>
             {
-                o.UseSqlite("Data Source=documents.db");
+                o.UseSqlite(DocumentDbContext.DefaultConnectionString);
                 o.AddInterceptors(sp.GetRequiredService<DocumentSaveChangesInterceptor>());
             });
             services.AddSingleton<IDocumentIndexService, DocumentIndexService>();

--- a/src/DocFinder.Services/DocumentDbContext.cs
+++ b/src/DocFinder.Services/DocumentDbContext.cs
@@ -5,6 +5,8 @@ namespace DocFinder.Services;
 
 public class DocumentDbContext : DbContext
 {
+    public const string DefaultConnectionString = "Data Source=documents.db";
+
     public DocumentDbContext()
     {
     }
@@ -18,7 +20,7 @@ public class DocumentDbContext : DbContext
     {
         if (!optionsBuilder.IsConfigured)
         {
-            optionsBuilder.UseSqlite("Data Source=documents.db");
+            optionsBuilder.UseSqlite(DefaultConnectionString);
         }
     }
 


### PR DESCRIPTION
## Summary
- centralize SQLite connection string in `DocumentDbContext`
- reuse shared constant in service registration

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5997b66448326993028b8524face0