### PR TITLE
Avoid unnecessary Task.Unwrap call in SettingsViewModel

### DIFF
--- a/src/DocFinder.UI/ViewModels/SettingsViewModel.cs
+++ b/src/DocFinder.UI/ViewModels/SettingsViewModel.cs
@@ -63,7 +63,8 @@ public partial class SettingsViewModel : ObservableObject
             return files;
         }, ct);
 
-        var reindexTask = Task.Run(() => _indexer.ReindexAllAsync(ct), ct).Unwrap();
+        // Start reindexing concurrently without wrapping in an extra Task
+        var reindexTask = _indexer.ReindexAllAsync(ct);
 
         var filesToIndex = await enumerateTask;
         foreach (var file in filesToIndex)


### PR DESCRIPTION
## Summary
- start reindexing without wrapping in Task.Run + Unwrap

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj` *(fails: hung, manually cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a380fed48326a0288e8787d189c8