### PR TITLE
Fix DocumentWindow ComboBox namespace

### DIFF
--- a/src/DocFinder.UI/Views/DocumentWindow.xaml
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml
@@ -24,16 +24,16 @@
                 <ui:TextBox x:Name="TypeFilter" Width="60" Margin="2" TextChanged="OnTextFilterChanged"/>
                 <ui:TextBox x:Name="IssuedFilter" Width="80" Margin="2" TextChanged="OnTextFilterChanged"/>
                 <ui:TextBox x:Name="ValidFilter" Width="80" Margin="2" TextChanged="OnTextFilterChanged"/>
-                <ui:ComboBox x:Name="CanPrintFilter" Width="60" Margin="2" SelectionChanged="OnBoolFilterChanged">
+                <ComboBox x:Name="CanPrintFilter" Width="60" Margin="2" SelectionChanged="OnBoolFilterChanged">
                     <ComboBoxItem Content=""/>
                     <ComboBoxItem Content="True"/>
                     <ComboBoxItem Content="False"/>
-                </ui:ComboBox>
-                <ui:ComboBox x:Name="ElectronicFilter" Width="60" Margin="2" SelectionChanged="OnBoolFilterChanged">
+                </ComboBox>
+                <ComboBox x:Name="ElectronicFilter" Width="60" Margin="2" SelectionChanged="OnBoolFilterChanged">
                     <ComboBoxItem Content=""/>
                     <ComboBoxItem Content="True"/>
                     <ComboBoxItem Content="False"/>
-                </ui:ComboBox>
+                </ComboBox>
             </StackPanel>
             <ui:DataGrid x:Name="documentsGrid" AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True" IsReadOnly="False"
                          RowEditEnding="DataGrid_RowEditEnding" PreviewKeyDown="DataGrid_PreviewKeyDown"


### PR DESCRIPTION
## Summary
- replace WPF UI ComboBox with standard WPF ComboBox in DocumentWindow

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a574d04083269f3f84c24d548e50