### PR TITLE
Add startup auto indexing

### DIFF
--- a/src/DocFinder.App/Services/ApplicationHostService.cs
+++ b/src/DocFinder.App/Services/ApplicationHostService.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Hosting;
 using DocFinder.Services;
 using DocFinder.UI.Views;
 using DocFinder.Indexing;
+using DocFinder.Domain.Settings;
 
 namespace DocFinder.Services;
 
@@ -11,22 +12,34 @@ public class ApplicationHostService : IHostedService
     private readonly SearchOverlay _overlay;
     private readonly SettingsWindow _settings;
     private readonly IWatcherService _watcher;
+    private readonly ISettingsService _settingsService;
+    private readonly IIndexer _indexer;
 
-    public ApplicationHostService(ITrayService tray, SearchOverlay overlay, SettingsWindow settings, IWatcherService watcher)
+    public ApplicationHostService(ITrayService tray,
+        SearchOverlay overlay,
+        SettingsWindow settings,
+        IWatcherService watcher,
+        ISettingsService settingsService,
+        IIndexer indexer)
     {
         _tray = tray;
         _overlay = overlay;
         _settings = settings;
         _watcher = watcher;
+        _settingsService = settingsService;
+        _indexer = indexer;
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         _watcher.Start();
         _tray.Initialize(ToggleOverlay, () => System.Windows.Application.Current.Shutdown(), ShowSettings);
         _overlay.Show();
         _overlay.Activate();
-        return Task.CompletedTask;
+        if (_settingsService.Current.AutoIndexOnStartup)
+        {
+            await _indexer.ReindexAllAsync(cancellationToken);
+        }
     }
 
     private void ToggleOverlay()


### PR DESCRIPTION
## Summary
- inject settings service and indexer into application host service
- run indexer at startup when auto-index setting is enabled

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a0048d048326bb80b4ec685477ec