### PR TITLE
Prompt to create database if missing

### DIFF
--- a/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
@@ -32,7 +32,29 @@ public partial class DocumentWindow : FluentWindow
         _context = dbOptions != null
             ? new DocumentDbContext(dbOptions)
             : new DocumentDbContext();
-        _context.Database.EnsureCreated();
+        var dbPath = _context.Database.GetDbConnection().DataSource;
+        if (!Path.IsPathRooted(dbPath))
+            dbPath = Path.GetFullPath(dbPath);
+        if (!File.Exists(dbPath))
+        {
+            var result = MessageBox.Show(
+                "Databáze nebyla nalezena. Vytvořit novou?",
+                "Chybějící databáze",
+                MessageBoxButton.YesNo);
+            if (result == MessageBoxResult.Yes)
+            {
+                _context.Database.EnsureCreated();
+            }
+            else
+            {
+                Close();
+                return;
+            }
+        }
+        else
+        {
+            _context.Database.EnsureCreated();
+        }
         _documents = new ObservableCollection<Document>(_context.Documents.ToList());
         documentsGrid.ItemsSource = _documents;
         _view = CollectionViewSource.GetDefaultView(_documents);


### PR DESCRIPTION
## Summary
- Check database file path before creating the database in `DocumentWindow`
- Ask user to create a new database if the file is missing and close on refusal

## Testing
- ⚠️ `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj` (build succeeded, test run hung) 
- ⚠️ `dotnet run --project src/DocFinder.App` (failed: Microsoft.NET.Sdk.WindowsDesktop.targets not found)

------
https://chatgpt.com/codex/tasks/task_e_68b6ba962a108326a114000715084bc4