### PR TITLE
Add message dialog service for user notifications

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -55,6 +55,7 @@ public partial class App
                     sp.GetRequiredService<IIndexer>(),
                     sp.GetRequiredService<ILogger<WatcherService>>()));
             services.AddSingleton<IDocumentViewService, DocumentViewService>();
+            services.AddSingleton<IMessageDialogService, MessageDialogService>();
             services.AddSingleton<SearchOverlayViewModel>();
             services.AddSingleton<SearchOverlay>();
             services.AddSingleton<SettingsViewModel>();

--- a/src/DocFinder.UI/Services/IMessageDialogService.cs
+++ b/src/DocFinder.UI/Services/IMessageDialogService.cs
@@ -1,0 +1,11 @@
+using System.Windows;
+
+namespace DocFinder.UI.Services;
+
+public interface IMessageDialogService
+{
+    void ShowInformation(string message, string title = "DocFinder");
+    void ShowWarning(string message, string title = "DocFinder");
+    void ShowError(string message, string title = "DocFinder");
+    bool ShowConfirmation(string message, string title = "DocFinder");
+}

--- a/src/DocFinder.UI/Services/MessageDialogService.cs
+++ b/src/DocFinder.UI/Services/MessageDialogService.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+
+namespace DocFinder.UI.Services;
+
+public sealed class MessageDialogService : IMessageDialogService
+{
+    public void ShowInformation(string message, string title = "DocFinder")
+        => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+
+    public void ShowWarning(string message, string title = "DocFinder")
+        => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Warning);
+
+    public void ShowError(string message, string title = "DocFinder")
+        => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Error);
+
+    public bool ShowConfirmation(string message, string title = "DocFinder")
+        => MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
+}

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml.cs
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml.cs
@@ -7,7 +7,6 @@ using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 using DocFinder.UI.ViewModels;
 using DocFinder.Indexing;
-using DocFinder.Services;
 using DocFinder.UI.Services;
 
 namespace DocFinder.UI.Views;
@@ -16,18 +15,18 @@ public partial class SearchOverlay : FluentWindow
 {
     private readonly SearchOverlayViewModel _viewModel;
     private readonly IIndexer _indexer;
-    private readonly ITrayService _tray;
     private readonly SettingsWindow _settings;
     private readonly IDocumentViewService _documentViewService;
+    private readonly IMessageDialogService _dialogs;
     private ResourceDictionary? _themeDictionary;
 
-    public SearchOverlay(SearchOverlayViewModel viewModel, IIndexer indexer, ITrayService tray, SettingsWindow settings, IDocumentViewService documentViewService)
+    public SearchOverlay(SearchOverlayViewModel viewModel, IIndexer indexer, SettingsWindow settings, IDocumentViewService documentViewService, IMessageDialogService dialogs)
     {
         _viewModel = viewModel;
         _indexer = indexer;
-        _tray = tray;
         _settings = settings;
         _documentViewService = documentViewService;
+        _dialogs = dialogs;
 
         InitializeComponent();
         ApplyTheme(ApplicationThemeManager.GetAppTheme());
@@ -88,14 +87,17 @@ public partial class SearchOverlay : FluentWindow
 
     private async void Menu_Reindex_Click(object sender, RoutedEventArgs e)
     {
+        if (!_dialogs.ShowConfirmation("Přeindexovat všechny dokumenty?", "DocFinder"))
+            return;
+
         try
         {
             await _indexer.ReindexAllAsync();
-            _tray.ShowNotification("DocFinder", "Přeindexování dokončeno");
+            _dialogs.ShowInformation("Přeindexování dokončeno", "DocFinder");
         }
         catch (Exception ex)
         {
-            _tray.ShowNotification("DocFinder", $"Přeindexování selhalo: {ex.Message}");
+            _dialogs.ShowError($"Přeindexování selhalo: {ex.Message}", "DocFinder");
         }
     }
 


### PR DESCRIPTION
## Summary
- Add reusable message dialog service for info, warning, error and confirmation dialogs
- Use dialog service for reindex operation in search overlay
- Register dialog service in application startup

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c4e2580083269e5be6ff5c86264b