### PR TITLE
feat: use Wpf.Ui message boxes

### DIFF
--- a/src/DocFinder.UI/Services/IMessageDialogService.cs
+++ b/src/DocFinder.UI/Services/IMessageDialogService.cs
@@ -1,5 +1,3 @@
-using System.Windows;
-
 namespace DocFinder.UI.Services;
 
 public interface IMessageDialogService

--- a/src/DocFinder.UI/Services/MessageDialogService.cs
+++ b/src/DocFinder.UI/Services/MessageDialogService.cs
@@ -1,18 +1,56 @@
-using System.Windows;
+using Wpf.Ui.Controls;
 
 namespace DocFinder.UI.Services;
 
 public sealed class MessageDialogService : IMessageDialogService
 {
     public void ShowInformation(string message, string title = "DocFinder")
-        => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+    {
+        var messageBox = new MessageBox
+        {
+            Title = title,
+            Content = message,
+            CloseButtonText = "OK"
+        };
+
+        messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+    }
 
     public void ShowWarning(string message, string title = "DocFinder")
-        => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Warning);
+    {
+        var messageBox = new MessageBox
+        {
+            Title = title,
+            Content = message,
+            CloseButtonText = "OK"
+        };
+
+        messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+    }
 
     public void ShowError(string message, string title = "DocFinder")
-        => MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Error);
+    {
+        var messageBox = new MessageBox
+        {
+            Title = title,
+            Content = message,
+            CloseButtonText = "OK"
+        };
+
+        messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+    }
 
     public bool ShowConfirmation(string message, string title = "DocFinder")
-        => MessageBox.Show(message, title, MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes;
+    {
+        var messageBox = new MessageBox
+        {
+            Title = title,
+            Content = message,
+            PrimaryButtonText = "Yes",
+            SecondaryButtonText = "No"
+        };
+
+        var result = messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+        return result == MessageBoxResult.Primary;
+    }
 }

--- a/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
@@ -13,6 +13,8 @@ using DocFinder.Services;
 using DocFinder.Search;
 using Microsoft.EntityFrameworkCore;
 using Wpf.Ui.Controls;
+using MessageBox = Wpf.Ui.Controls.MessageBox;
+using MessageBoxResult = Wpf.Ui.Controls.MessageBoxResult;
 
 namespace DocFinder.UI.Views;
 
@@ -37,11 +39,16 @@ public partial class DocumentWindow : FluentWindow
             dbPath = Path.GetFullPath(dbPath);
         if (!File.Exists(dbPath))
         {
-            var result = MessageBox.Show(
-                "Databáze nebyla nalezena. Vytvořit novou?",
-                "Chybějící databáze",
-                MessageBoxButton.YesNo);
-            if (result == MessageBoxResult.Yes)
+            var messageBox = new MessageBox
+            {
+                Title = "Chybějící databáze",
+                Content = "Databáze nebyla nalezena. Vytvořit novou?",
+                PrimaryButtonText = "Yes",
+                SecondaryButtonText = "No"
+            };
+
+            var result = messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+            if (result == MessageBoxResult.Primary)
             {
                 _context.Database.EnsureCreated();
             }
@@ -150,7 +157,13 @@ public partial class DocumentWindow : FluentWindow
             }
             else
             {
-                System.Windows.MessageBox.Show("Soubor neexistuje.");
+                var messageBox = new MessageBox
+                {
+                    Title = "DocFinder",
+                    Content = "Soubor neexistuje.",
+                    CloseButtonText = "OK"
+                };
+                messageBox.ShowDialogAsync().GetAwaiter().GetResult();
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace message dialog service and window prompts with Wpf.Ui `MessageBox`
- drop `System.Windows` dependency from message dialog interface

## Testing
- `dotnet build DocFinder.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c7221f808326aa59414010a82fc3