### PR TITLE
Add tray mode and toast notifications

### DIFF
--- a/src/DocFinder.App/App.xaml
+++ b/src/DocFinder.App/App.xaml
@@ -5,7 +5,8 @@
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     DispatcherUnhandledException="OnDispatcherUnhandledException"
     Exit="OnExit"
-    Startup="OnStartup">
+    Startup="OnStartup"
+    ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -28,6 +28,7 @@ public partial class App
         .ConfigureServices((context, services) =>
         {
             services.AddHostedService<ApplicationHostService>();
+            services.AddHostedService<AutomaticIndexingService>();
             services.AddSingleton<ITrayService, TrayService>();
             services.AddSingleton<ISettingsService, SettingsService>();
             services.AddSingleton<ISearchService, LuceneSearchService>();

--- a/src/DocFinder.App/Services/ApplicationHostService.cs
+++ b/src/DocFinder.App/Services/ApplicationHostService.cs
@@ -34,8 +34,6 @@ public class ApplicationHostService : IHostedService
     {
         _watcher.Start();
         _tray.Initialize(ToggleOverlay, () => System.Windows.Application.Current.Shutdown(), ShowSettings);
-        _overlay.Show();
-        _overlay.Activate();
         if (_settingsService.Current.AutoIndexOnStartup)
         {
             await _indexer.ReindexAllAsync(cancellationToken);

--- a/src/DocFinder.App/Services/AutomaticIndexingService.cs
+++ b/src/DocFinder.App/Services/AutomaticIndexingService.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Hosting;
+using DocFinder.Indexing;
+
+namespace DocFinder.Services;
+
+public class AutomaticIndexingService : BackgroundService
+{
+    private readonly IIndexer _indexer;
+    private readonly ITrayService _tray;
+
+    public AutomaticIndexingService(IIndexer indexer, ITrayService tray)
+    {
+        _indexer = indexer;
+        _tray = tray;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await _indexer.ReindexAllAsync(stoppingToken);
+            _tray.ShowNotification("DocFinder", "Automatické indexování dokončeno");
+            await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
+        }
+    }
+}

--- a/src/DocFinder.Services/DocFinder.Services.csproj
+++ b/src/DocFinder.Services/DocFinder.Services.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CommunityToolkit.WinUI.Notifications" Version="7.1.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DocFinder.Domain\DocFinder.Domain.csproj" />

--- a/src/DocFinder.Services/TrayService.cs
+++ b/src/DocFinder.Services/TrayService.cs
@@ -1,6 +1,7 @@
 #if WINDOWS
 using System;
 using System.Windows.Forms;
+using CommunityToolkit.WinUI.Notifications;
 
 namespace DocFinder.Services;
 
@@ -36,7 +37,17 @@ public sealed class TrayService : ITrayService
 
     public void ShowNotification(string title, string message)
     {
-        _icon?.ShowBalloonTip(3000, title, message, ToolTipIcon.Info);
+        if (OperatingSystem.IsWindowsVersionAtLeast(10))
+        {
+            new ToastContentBuilder()
+                .AddText(title)
+                .AddText(message)
+                .Show();
+        }
+        else
+        {
+            _icon?.ShowBalloonTip(3000, title, message, ToolTipIcon.Info);
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- integrate Windows toast notifications and tray service
- allow background operation with explicit shutdown and automatic indexing service

## Testing
- `dotnet restore`
- `dotnet test --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c66cef1c8326810db403686aa6dd