### PR TITLE
Show search overlay at startup

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -73,6 +73,9 @@ public partial class App
         await settings.LoadAsync();
 
         await _host.StartAsync();
+
+        var overlay = Services.GetRequiredService<SearchOverlay>();
+        overlay.Show();
     }
 
     private async void OnExit(object sender, ExitEventArgs e)


### PR DESCRIPTION
## Summary
- display SearchOverlay window when application starts

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*
- `dotnet run --project src/DocFinder.App` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e02db9bc8326a27cf4e921cbe137