### PR TITLE
feat: add file list aggregate

### DIFF
--- a/src/DocFinder.Catalog/CatalogDbContext.cs
+++ b/src/DocFinder.Catalog/CatalogDbContext.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using FileEntity = DocFinder.Domain.File;
 using DataEntity = DocFinder.Domain.Data;
+using FileListEntity = DocFinder.Domain.FileList;
+using FileListItemEntity = DocFinder.Domain.FileListItem;
 
 namespace DocFinder.Catalog;
 
@@ -13,6 +15,8 @@ public class CatalogDbContext : DbContext
 
     public DbSet<FileEntity> Files => Set<FileEntity>();
     public DbSet<DataEntity> Data => Set<DataEntity>();
+    public DbSet<FileListEntity> FileLists => Set<FileListEntity>();
+    public DbSet<FileListItemEntity> FileListItems => Set<FileListItemEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/DocFinder.Catalog/FileListConfiguration.cs
+++ b/src/DocFinder.Catalog/FileListConfiguration.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using DocFinder.Domain;
+
+namespace DocFinder.Catalog;
+
+/// <summary>EF Core configuration for <see cref="FileList"/>.</summary>
+public sealed class FileListConfiguration : IEntityTypeConfiguration<FileList>
+{
+    public void Configure(EntityTypeBuilder<FileList> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.RowVersion).IsRowVersion();
+        builder.Property(x => x.Name).IsRequired().HasMaxLength(256);
+        builder.Property(x => x.Owner).IsRequired().HasMaxLength(128);
+
+        builder.HasMany<FileListItem>()
+               .WithOne()
+               .HasForeignKey(i => i.ListId)
+               .OnDelete(DeleteBehavior.Cascade);
+    }
+}
+
+/// <summary>EF Core configuration for <see cref="FileListItem"/>.</summary>
+public sealed class FileListItemConfiguration : IEntityTypeConfiguration<FileListItem>
+{
+    public void Configure(EntityTypeBuilder<FileListItem> itemBuilder)
+    {
+        itemBuilder.HasKey(i => i.Id);
+        itemBuilder.Property(i => i.RowVersion).IsRowVersion();
+        itemBuilder.HasIndex(i => new { i.ListId, i.FileId }).IsUnique();
+        itemBuilder.HasIndex(i => new { i.ListId, i.Order }).IsUnique();
+        itemBuilder.Property(i => i.PinnedSha256).HasMaxLength(64);
+        itemBuilder.Property(i => i.Label).HasMaxLength(256);
+        itemBuilder.Property(i => i.Note).HasMaxLength(2000);
+
+        itemBuilder.HasOne(i => i.File)
+                   .WithMany()
+                   .HasForeignKey(i => i.FileId)
+                   .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/DocFinder.Domain/FileList.cs
+++ b/src/DocFinder.Domain/FileList.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DocFinder.Domain;
+
+/// <summary>
+/// Aggregate root representing an ordered list of files.
+/// </summary>
+public sealed class FileList
+{
+    private readonly List<FileListItem> _items = new();
+
+    // For EF Core
+    private FileList() { }
+
+    public FileList(Guid id, string name, DateTime createdUtc, string owner)
+    {
+        Id = id;
+        Name = Require(name);
+        Owner = Require(owner);
+        CreatedUtc = createdUtc;
+        ModifiedUtc = createdUtc;
+    }
+
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string Owner { get; private set; } = string.Empty;
+    public DateTime CreatedUtc { get; private set; }
+    public DateTime ModifiedUtc { get; private set; }
+    public byte[] RowVersion { get; private set; } = Array.Empty<byte>();
+
+    public IReadOnlyList<FileListItem> Items => _items.OrderBy(i => i.Order).ToList();
+    public int Count => _items.Count;
+
+    public bool ContainsFile(Guid fileId) => _items.Any(i => i.FileId == fileId);
+
+    /// <summary>
+    /// Adds multiple files to the end of the list. Skips duplicates within this list.
+    /// Optionally pins each item to the file's current checksum.
+    /// Returns the created items in the final order.
+    /// </summary>
+    public IReadOnlyList<FileListItem> AddFiles(IEnumerable<File> files, bool pinToChecksum = false)
+    {
+        if (files is null) throw new ArgumentNullException(nameof(files));
+
+        var created = new List<FileListItem>();
+        foreach (var file in files)
+        {
+            if (file is null) continue;
+            if (ContainsFile(file.FileId)) continue;
+
+            var pinned = pinToChecksum ? file.Sha256 : null;
+            var item = new FileListItem(
+                id: Guid.NewGuid(),
+                listId: Id,
+                fileId: file.FileId,
+                order: _items.Count,
+                label: null,
+                note: null,
+                pinnedSha256: pinned,
+                addedUtc: DateTime.UtcNow
+            );
+            _items.Add(item);
+            created.Add(item);
+        }
+
+        if (created.Count > 0)
+        {
+            NormalizeOrder();
+            Touch();
+        }
+        return created;
+    }
+
+    /// <summary>
+    /// Inserts multiple files starting at a given index (keeps input order). Skips duplicates within this list.
+    /// </summary>
+    public IReadOnlyList<FileListItem> InsertFiles(int index, IEnumerable<File> files, bool pinToChecksum = false)
+    {
+        if (files is null) throw new ArgumentNullException(nameof(files));
+        index = ClampIndex(index);
+
+        var created = new List<FileListItem>();
+        foreach (var file in files)
+        {
+            if (file is null) continue;
+            if (ContainsFile(file.FileId)) continue;
+
+            var pinned = pinToChecksum ? file.Sha256 : null;
+            var item = new FileListItem(
+                id: Guid.NewGuid(),
+                listId: Id,
+                fileId: file.FileId,
+                order: index,
+                label: null,
+                note: null,
+                pinnedSha256: pinned,
+                addedUtc: DateTime.UtcNow
+            );
+            _items.Insert(index++, item);
+            created.Add(item);
+        }
+
+        if (created.Count > 0)
+        {
+            NormalizeOrder();
+            Touch();
+        }
+        return created;
+    }
+
+    /// <summary>Moves the specified file to a new position.</summary>
+    public void Reorder(Guid fileId, int newIndex)
+    {
+        var item = _items.First(i => i.FileId == fileId);
+        _items.Remove(item);
+        newIndex = ClampIndex(newIndex);
+        _items.Insert(newIndex, item);
+        NormalizeOrder();
+        Touch();
+    }
+
+    public void PinFile(Guid fileId, string sha256)
+    {
+        var item = _items.First(i => i.FileId == fileId);
+        item.Pin(sha256);
+        Touch();
+    }
+
+    public void UnpinFile(Guid fileId)
+    {
+        var item = _items.First(i => i.FileId == fileId);
+        item.Unpin();
+        Touch();
+    }
+
+    private int ClampIndex(int index) => Math.Max(0, Math.Min(index, _items.Count));
+
+    private void NormalizeOrder()
+    {
+        for (int i = 0; i < _items.Count; i++)
+            _items[i].SetOrder(i);
+    }
+
+    private void Touch(DateTime? modifiedUtc = null)
+    {
+        ModifiedUtc = modifiedUtc ?? DateTime.UtcNow;
+    }
+
+    private static string Require(string value)
+        => string.IsNullOrWhiteSpace(value) ? throw new ArgumentException("Value is required") : value.Trim();
+}

--- a/src/DocFinder.Domain/FileListItem.cs
+++ b/src/DocFinder.Domain/FileListItem.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace DocFinder.Domain;
+
+/// <summary>
+/// Item in a <see cref="FileList"/> referencing a concrete file.
+/// </summary>
+public sealed class FileListItem
+{
+    // For EF Core
+    private FileListItem() { }
+
+    public FileListItem(Guid id, Guid listId, Guid fileId, int order, string? label, string? note, string? pinnedSha256, DateTime addedUtc)
+    {
+        Id = id;
+        ListId = listId;
+        FileId = fileId;
+        Order = order;
+        Label = label;
+        Note = note;
+        PinnedSha256 = pinnedSha256;
+        AddedUtc = addedUtc;
+    }
+
+    public Guid Id { get; private set; }
+    public Guid ListId { get; private set; }
+    public Guid FileId { get; private set; }
+    public int Order { get; private set; }
+    public string? Label { get; private set; }
+    public string? Note { get; private set; }
+    public string? PinnedSha256 { get; private set; }
+    public DateTime AddedUtc { get; private set; }
+    public byte[] RowVersion { get; private set; } = Array.Empty<byte>();
+
+    public File File { get; private set; } = null!;
+
+    internal void SetOrder(int order) => Order = order;
+    internal void Pin(string sha256) => PinnedSha256 = sha256;
+    internal void Unpin() => PinnedSha256 = null;
+}

--- a/src/DocFinder.Tests/FileListTests.cs
+++ b/src/DocFinder.Tests/FileListTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using DocFinder.Domain;
+using FileEntity = DocFinder.Domain.File;
+using Xunit;
+
+namespace DocFinder.Tests;
+
+public class FileListTests
+{
+    private static FileEntity CreateFile(byte[]? content = null)
+    {
+        var bytes = content ?? new byte[] { 1 };
+        var data = new Data(Guid.NewGuid(), "v1", "application/octet-stream", bytes);
+        return new FileEntity(Guid.NewGuid(), "a/b", "name", "txt", DateTime.UtcNow, "auth", data);
+    }
+
+    [Fact]
+    public void AddFiles_AddsInOrderAndSkipsDuplicates()
+    {
+        var list = new FileList(Guid.NewGuid(), "list", DateTime.UtcNow, "owner");
+        var a = CreateFile();
+        var b = CreateFile();
+        var c = CreateFile();
+
+        list.AddFiles(new[] { a, b, c });
+        list.AddFiles(new[] { a }); // duplicate
+
+        Assert.Equal(3, list.Count);
+        Assert.Equal(new[] { a.FileId, b.FileId, c.FileId }, list.Items.Select(i => i.FileId));
+    }
+
+    [Fact]
+    public void InsertFiles_InsertsAtIndex()
+    {
+        var list = new FileList(Guid.NewGuid(), "list", DateTime.UtcNow, "owner");
+        var a = CreateFile();
+        var b = CreateFile();
+        var c = CreateFile();
+        list.AddFiles(new[] { a, b, c });
+
+        var x = CreateFile();
+        var y = CreateFile();
+        list.InsertFiles(1, new[] { x, y });
+
+        Assert.Equal(new[] { a.FileId, x.FileId, y.FileId, b.FileId, c.FileId },
+            list.Items.Select(i => i.FileId));
+    }
+
+    [Fact]
+    public void Reorder_MovesItemToNewIndex()
+    {
+        var list = new FileList(Guid.NewGuid(), "list", DateTime.UtcNow, "owner");
+        var a = CreateFile();
+        var b = CreateFile();
+        var c = CreateFile();
+        list.AddFiles(new[] { a, b, c });
+
+        list.Reorder(b.FileId, 2);
+
+        Assert.Equal(new[] { a.FileId, c.FileId, b.FileId }, list.Items.Select(i => i.FileId));
+    }
+
+    [Fact]
+    public void PinAndUnpin_Works()
+    {
+        var list = new FileList(Guid.NewGuid(), "list", DateTime.UtcNow, "owner");
+        var file = CreateFile();
+        list.AddFiles(new[] { file });
+
+        list.PinFile(file.FileId, file.Sha256);
+        Assert.Equal(file.Sha256, list.Items.Single().PinnedSha256);
+
+        list.UnpinFile(file.FileId);
+        Assert.Null(list.Items.Single().PinnedSha256);
+    }
+}


### PR DESCRIPTION
## Summary
- implement FileList aggregate with bulk add/insert, reordering, and pinning support
- map FileList and FileListItem entities in EF Core with unique constraints for files and order
- add unit tests covering add, insert, reorder, and pin/unpin behaviors

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj --filter FileListTests`
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj` *(fails: Microsoft.Data.Sqlite.SqliteException)*

------
https://chatgpt.com/codex/tasks/task_e_68b75359f74883268d72718b71c21f50