### PR TITLE
Add ProtocolList aggregate and EF mapping with tests

### DIFF
--- a/src/DocFinder.Domain/ProtocolList.cs
+++ b/src/DocFinder.Domain/ProtocolList.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace DocFinder.Domain;
+
+public sealed class ProtocolList
+{
+    // For EF Core
+    private ProtocolList() { }
+
+    public ProtocolList(Guid id, string name, DateTime createdUtc, string owner)
+    {
+        Id = id;
+        Rename(name);
+        SetOwner(owner);
+        SetCreated(createdUtc);
+        ModifiedUtc = CreatedUtc;
+    }
+
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string? Description { get; private set; }
+    public string Owner { get; private set; } = string.Empty;
+
+    public bool IsArchived { get; private set; }
+    public DateTime CreatedUtc { get; private set; }
+    public DateTime ModifiedUtc { get; private set; }
+
+    /// <summary>Optimistic concurrency token.</summary>
+    public byte[] RowVersion { get; private set; } = Array.Empty<byte>();
+
+    private readonly List<ProtocolListItem> _items = new();
+    public IReadOnlyList<ProtocolListItem> Items => new ReadOnlyCollection<ProtocolListItem>(_items);
+    public int Count => _items.Count;
+
+    // ---------- Behaviour ----------
+
+    public void Rename(string name) => Name = Require(name).Trim();
+    public void SetDescription(string? description) => Description = description?.Trim();
+    public void SetOwner(string owner) => Owner = Require(owner).Trim();
+
+    public void SetCreated(DateTime createdUtc)
+    {
+        EnsureUtc(createdUtc, nameof(createdUtc));
+        CreatedUtc = createdUtc;
+    }
+
+    public void Touch(DateTime? modifiedUtc = null)
+    {
+        var now = modifiedUtc ?? DateTime.UtcNow;
+        EnsureUtc(now, nameof(modifiedUtc));
+        if (now < CreatedUtc) throw new InvalidOperationException("ModifiedUtc cannot be earlier than CreatedUtc.");
+        ModifiedUtc = now;
+    }
+
+    public void Archive()   { if (!IsArchived) { IsArchived = true;  Touch(); } }
+    public void Unarchive() { if (IsArchived)  { IsArchived = false; Touch(); } }
+
+    public bool ContainsProtocol(Guid protocolId) => _items.Any(i => i.ProtocolId == protocolId);
+
+    /// <summary>Add a protocol to the end of the list. Prevents duplicates.</summary>
+    public ProtocolListItem AddProtocol(Protocol protocol, string? label = null, string? note = null,
+                                        bool pinToProtocolVersion = false, bool pinToFileChecksum = false)
+        => InsertProtocol(Count, protocol, label, note, pinToProtocolVersion, pinToFileChecksum);
+
+    /// <summary>Insert a protocol at a specific index. Prevents duplicates.</summary>
+    public ProtocolListItem InsertProtocol(int index, Protocol protocol, string? label = null, string? note = null,
+                                           bool pinToProtocolVersion = false, bool pinToFileChecksum = false)
+    {
+        if (protocol is null) throw new ArgumentNullException(nameof(protocol));
+        if (ContainsProtocol(protocol.Id))
+            throw new InvalidOperationException($"Protocol {protocol.Id} is already in the list.");
+
+        index = ClampIndex(index);
+
+        var pinnedVersion  = pinToProtocolVersion ? protocol.Version : null;
+        var pinnedChecksum = pinToFileChecksum   ? protocol.File?.Sha256 : null;
+
+        var item = new ProtocolListItem(
+            id: Guid.NewGuid(),
+            listId: Id,
+            protocolId: protocol.Id,
+            order: index,
+            label: label,
+            note: note,
+            pinnedVersion: pinnedVersion,
+            pinnedFileSha256: pinnedChecksum,
+            addedUtc: DateTime.UtcNow
+        );
+
+        _items.Insert(index, item);
+        NormalizeOrder();
+        Touch();
+        return item;
+    }
+
+    /// <summary>Add multiple protocols (skips duplicates, keeps input order).</summary>
+    public IReadOnlyList<ProtocolListItem> AddProtocols(IEnumerable<Protocol> protocols,
+        bool pinToProtocolVersion = false, bool pinToFileChecksum = false)
+    {
+        if (protocols is null) throw new ArgumentNullException(nameof(protocols));
+
+        var created = new List<ProtocolListItem>();
+        foreach (var protocol in protocols)
+        {
+            if (protocol is null) continue;
+            if (ContainsProtocol(protocol.Id)) continue;
+
+            var item = new ProtocolListItem(
+                id: Guid.NewGuid(),
+                listId: Id,
+                protocolId: protocol.Id,
+                order: _items.Count,
+                label: null,
+                note: null,
+                pinnedVersion: pinToProtocolVersion ? protocol.Version : null,
+                pinnedFileSha256: pinToFileChecksum ? protocol.File?.Sha256 : null,
+                addedUtc: DateTime.UtcNow
+            );
+
+            _items.Add(item);
+            created.Add(item);
+        }
+
+        if (created.Count > 0)
+        {
+            NormalizeOrder();
+            Touch();
+        }
+        return created;
+    }
+
+    public void RemoveProtocol(Guid protocolId)
+    {
+        var idx = _items.FindIndex(i => i.ProtocolId == protocolId);
+        if (idx < 0) return;
+        _items.RemoveAt(idx);
+        NormalizeOrder();
+        Touch();
+    }
+
+    public void Clear()
+    {
+        if (_items.Count == 0) return;
+        _items.Clear();
+        Touch();
+    }
+
+    public void Reorder(Guid protocolId, int newIndex)
+    {
+        var current = _items.FindIndex(i => i.ProtocolId == protocolId);
+        if (current < 0) throw new InvalidOperationException($"Protocol {protocolId} not found in the list.");
+
+        newIndex = ClampIndex(newIndex);
+        if (current == newIndex) return;
+
+        var item = _items[current];
+        _items.RemoveAt(current);
+        _items.Insert(newIndex, item);
+        NormalizeOrder();
+        Touch();
+    }
+
+    public void PinToVersion(Guid protocolId, string version)
+    {
+        var item = GetItem(protocolId);
+        item.PinToVersion(Require(version));
+        Touch();
+    }
+
+    public void UnpinVersion(Guid protocolId)
+    {
+        var item = GetItem(protocolId);
+        item.UnpinVersion();
+        Touch();
+    }
+
+    public void PinToFileChecksum(Guid protocolId, string sha256)
+    {
+        var item = GetItem(protocolId);
+        item.PinToFileChecksum(Require(sha256));
+        Touch();
+    }
+
+    public void UnpinFileChecksum(Guid protocolId)
+    {
+        var item = GetItem(protocolId);
+        item.UnpinFileChecksum();
+        Touch();
+    }
+
+    public void SetItemLabel(Guid protocolId, string? label) { GetItem(protocolId).SetLabel(label); Touch(); }
+    public void SetItemNote (Guid protocolId, string? note)  { GetItem(protocolId).SetNote(note);  Touch(); }
+
+    // ---------- helpers ----------
+    private ProtocolListItem GetItem(Guid protocolId)
+        => _items.FirstOrDefault(i => i.ProtocolId == protocolId)
+           ?? throw new InvalidOperationException($"Protocol {protocolId} not found in the list.");
+
+    private int ClampIndex(int index) => Math.Max(0, Math.Min(index, _items.Count));
+
+    private void NormalizeOrder()
+    {
+        for (int i = 0; i < _items.Count; i++)
+            _items[i].SetOrder(i);
+    }
+
+    private static string Require(string v)
+        => string.IsNullOrWhiteSpace(v) ? throw new ArgumentException("Value is required.") : v;
+
+    private static void EnsureUtc(DateTime dt, string paramName)
+    {
+        if (dt.Kind != DateTimeKind.Utc)
+            throw new ArgumentException("DateTime must be in UTC.", paramName);
+    }
+}

--- a/src/DocFinder.Domain/ProtocolListItem.cs
+++ b/src/DocFinder.Domain/ProtocolListItem.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace DocFinder.Domain;
+
+public sealed class ProtocolListItem
+{
+    // For EF Core
+    private ProtocolListItem() { }
+
+    internal ProtocolListItem(Guid id, Guid listId, Guid protocolId, int order,
+                              string? label, string? note,
+                              string? pinnedVersion, string? pinnedFileSha256,
+                              DateTime addedUtc)
+    {
+        Id = id;
+        ListId = listId;
+        ProtocolId = protocolId;
+
+        SetOrder(order);
+        SetLabel(label);
+        SetNote(note);
+
+        if (!string.IsNullOrWhiteSpace(pinnedVersion))     PinnedVersion = pinnedVersion.Trim();
+        if (!string.IsNullOrWhiteSpace(pinnedFileSha256))  PinnedFileSha256 = pinnedFileSha256.Trim();
+
+        SetAdded(addedUtc);
+    }
+
+    public Guid Id { get; private set; }
+    public Guid ListId { get; private set; }
+
+    public Guid ProtocolId { get; private set; }
+    public Protocol? Protocol { get; private set; } // optional navigation
+
+    /// <summary>Zero-based order within the list.</summary>
+    public int Order { get; private set; }
+
+    public string? Label { get; private set; }
+    public string? Note  { get; private set; }
+
+    /// <summary>If set, this item is pinned to a specific protocol version string.</summary>
+    public string? PinnedVersion { get; private set; }
+
+    /// <summary>If set, this item is pinned to the protocol's file SHA-256.</summary>
+    public string? PinnedFileSha256 { get; private set; }
+
+    public DateTime AddedUtc { get; private set; }
+
+    public byte[] RowVersion { get; private set; } = Array.Empty<byte>();
+
+    // ---- item-level behaviour ----
+    internal void SetOrder(int order)
+    {
+        if (order < 0) throw new ArgumentOutOfRangeException(nameof(order));
+        Order = order;
+    }
+
+    public void SetLabel(string? label) => Label = string.IsNullOrWhiteSpace(label) ? null : label.Trim();
+    public void SetNote (string? note)  => Note  = string.IsNullOrWhiteSpace(note)  ? null : note.Trim();
+
+    public void PinToVersion(string version)
+    {
+        if (string.IsNullOrWhiteSpace(version)) throw new ArgumentException("Version required.", nameof(version));
+        PinnedVersion = version.Trim();
+    }
+
+    public void UnpinVersion() => PinnedVersion = null;
+
+    public void PinToFileChecksum(string sha256)
+    {
+        if (string.IsNullOrWhiteSpace(sha256)) throw new ArgumentException("Checksum required.", nameof(sha256));
+        PinnedFileSha256 = sha256.Trim();
+    }
+
+    public void UnpinFileChecksum() => PinnedFileSha256 = null;
+
+    public void SetAdded(DateTime addedUtc)
+    {
+        if (addedUtc.Kind != DateTimeKind.Utc) throw new ArgumentException("DateTime must be UTC.", nameof(addedUtc));
+        AddedUtc = addedUtc;
+    }
+}

--- a/src/DocFinder.Services/DocumentDbContext.cs
+++ b/src/DocFinder.Services/DocumentDbContext.cs
@@ -26,4 +26,12 @@ public class DocumentDbContext : DbContext
 
     public DbSet<Protocol> Protocols => Set<Protocol>();
     public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
+    public DbSet<ProtocolList> ProtocolLists => Set<ProtocolList>();
+    public DbSet<ProtocolListItem> ProtocolListItems => Set<ProtocolListItem>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(DocumentDbContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
 }

--- a/src/DocFinder.Services/ProtocolListConfiguration.cs
+++ b/src/DocFinder.Services/ProtocolListConfiguration.cs
@@ -1,0 +1,56 @@
+using DocFinder.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DocFinder.Services;
+
+public sealed class ProtocolListConfiguration : IEntityTypeConfiguration<ProtocolList>
+{
+    public void Configure(EntityTypeBuilder<ProtocolList> b)
+    {
+        b.ToTable("ProtocolLists");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.Name).IsRequired().HasMaxLength(256);
+        b.Property(x => x.Owner).IsRequired().HasMaxLength(128);
+        b.Property(x => x.Description).HasMaxLength(2000);
+        b.Property(x => x.CreatedUtc).IsRequired();
+        b.Property(x => x.ModifiedUtc).IsRequired();
+        b.Property(x => x.RowVersion).IsRowVersion();
+
+        b.HasMany<ProtocolListItem>()
+         .WithOne()
+         .HasForeignKey(i => i.ListId)
+         .OnDelete(DeleteBehavior.Cascade);
+    }
+}
+
+public sealed class ProtocolListItemConfiguration : IEntityTypeConfiguration<ProtocolListItem>
+{
+    public void Configure(EntityTypeBuilder<ProtocolListItem> b)
+    {
+        b.ToTable("ProtocolListItems");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.RowVersion).IsRowVersion();
+        b.Property(x => x.Order).IsRequired();
+        b.Property(x => x.AddedUtc).IsRequired();
+
+        b.Property(x => x.Label).HasMaxLength(256);
+        b.Property(x => x.Note).HasMaxLength(2000);
+        b.Property(x => x.PinnedVersion).HasMaxLength(64);
+        b.Property(x => x.PinnedFileSha256).HasMaxLength(64);
+
+        // unikát: jeden Protocol jen jednou v daném seznamu
+        b.HasIndex(x => new { x.ListId, x.ProtocolId }).IsUnique();
+
+        // unikát: jedno pořadí per seznam
+        b.HasIndex(x => new { x.ListId, x.Order }).IsUnique();
+
+        // volitelná navigace na Protocol
+        b.HasOne(x => x.Protocol)
+         .WithMany()
+         .HasForeignKey(x => x.ProtocolId)
+         .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/DocFinder.Tests/ProtocolListTests.cs
+++ b/src/DocFinder.Tests/ProtocolListTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using DocFinder.Domain;
+using Xunit;
+using FileEntity = DocFinder.Domain.File;
+using ProtocolEntity = DocFinder.Domain.Protocol;
+
+namespace DocFinder.Tests;
+
+public class ProtocolListTests
+{
+    private static FileEntity CreateFile(byte[]? content = null)
+    {
+        var bytes = content ?? new byte[] { 1 };
+        var data = new Data(Guid.NewGuid(), "v1", "application/octet-stream", bytes);
+        return new FileEntity(Guid.NewGuid(), "a/b", "name", "txt", DateTime.UtcNow, "auth", data);
+    }
+
+    private static ProtocolEntity CreateProtocol(string? version = null, byte[]? content = null)
+    {
+        var file = CreateFile(content);
+        var protocol = new ProtocolEntity(Guid.NewGuid(), file, "title", "ref", ProtocolType.Other,
+            DateTime.UtcNow, "issuer", null, "resp");
+        if (version is not null)
+            protocol.SetVersion(version);
+        return protocol;
+    }
+
+    [Fact]
+    public void AddProtocols_AddsInOrderAndSkipsDuplicates()
+    {
+        var list = new ProtocolList(Guid.NewGuid(), "list", DateTime.UtcNow, "owner");
+        var a = CreateProtocol();
+        var b = CreateProtocol();
+        var c = CreateProtocol();
+
+        list.AddProtocols(new[] { a, b, c });
+        list.AddProtocols(new[] { a }); // duplicate
+
+        Assert.Equal(3, list.Count);
+        Assert.Equal(new[] { a.Id, b.Id, c.Id }, list.Items.Select(i => i.ProtocolId));
+    }
+
+    [Fact]
+    public void Reorder_MovesItemToNewIndex()
+    {
+        var list = new ProtocolList(Guid.NewGuid(), "list", DateTime.UtcNow, "owner");
+        var a = CreateProtocol();
+        var b = CreateProtocol();
+        var c = CreateProtocol();
+        list.AddProtocols(new[] { a, b, c });
+
+        list.Reorder(b.Id, 2);
+
+        Assert.Equal(new[] { a.Id, c.Id, b.Id }, list.Items.Select(i => i.ProtocolId));
+    }
+
+    [Fact]
+    public void PinAndUnpin_Works()
+    {
+        var list = new ProtocolList(Guid.NewGuid(), "list", DateTime.UtcNow, "owner");
+        var protocol = CreateProtocol(version: "v1");
+        list.AddProtocol(protocol, pinToProtocolVersion: true, pinToFileChecksum: true);
+
+        var item = list.Items.Single();
+        Assert.Equal("v1", item.PinnedVersion);
+        Assert.Equal(protocol.File.Sha256, item.PinnedFileSha256);
+
+        list.UnpinVersion(protocol.Id);
+        list.UnpinFileChecksum(protocol.Id);
+
+        item = list.Items.Single();
+        Assert.Null(item.PinnedVersion);
+        Assert.Null(item.PinnedFileSha256);
+    }
+}


### PR DESCRIPTION
## Summary
- add ProtocolList aggregate root and ProtocolListItem entity for managing ordered protocol collections with pinning support
- map ProtocolList and items via EF Core configuration and extend `DocumentDbContext`
- cover ProtocolList with unit tests for duplicates, reorder and pin/unpin

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c2778b288326ac503e22cc7fc5bd