### PR TITLE
Add generic EF repository pattern

### DIFF
--- a/src/DocFinder.Domain/Repositories/EntityRepositories.cs
+++ b/src/DocFinder.Domain/Repositories/EntityRepositories.cs
@@ -1,0 +1,12 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Domain;
+
+public interface IAuditEntryRepository : IRepository<AuditEntry> { }
+public interface IDataRepository : IRepository<Data> { }
+public interface IFileRepository : IRepository<File> { }
+public interface IFileListRepository : IRepository<FileList> { }
+public interface IFileListItemRepository : IRepository<FileListItem> { }
+public interface IProtocolRepository : IRepository<Protocol> { }
+public interface IProtocolListRepository : IRepository<ProtocolList> { }
+public interface IProtocolListItemRepository : IRepository<ProtocolListItem> { }

--- a/src/DocFinder.Domain/Repositories/IRepository.cs
+++ b/src/DocFinder.Domain/Repositories/IRepository.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DocFinder.Domain;
+
+/// <summary>
+/// Generic repository interface providing basic CRUD operations with
+/// optional filtering, sorting and transaction support.
+/// </summary>
+public interface IRepository<T> where T : class
+{
+    Task<T?> FirstOrDefaultAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default);
+
+    Task<IReadOnlyList<T>> ListAsync(
+        Expression<Func<T, bool>>? filter = null,
+        Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null,
+        CancellationToken ct = default);
+
+    Task AddAsync(T entity, CancellationToken ct = default);
+    Task UpdateAsync(T entity, CancellationToken ct = default);
+    Task DeleteAsync(T entity, CancellationToken ct = default);
+
+    Task ExecuteInTransactionAsync(Func<CancellationToken, Task> operation, CancellationToken ct = default);
+}

--- a/src/DocFinder.Services/Repositories/AuditEntryRepository.cs
+++ b/src/DocFinder.Services/Repositories/AuditEntryRepository.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class AuditEntryRepository : EfRepository<AuditEntry>, IAuditEntryRepository
+{
+    public AuditEntryRepository(DocumentDbContext context) : base(context) { }
+}

--- a/src/DocFinder.Services/Repositories/DataRepository.cs
+++ b/src/DocFinder.Services/Repositories/DataRepository.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class DataRepository : EfRepository<Data>, IDataRepository
+{
+    public DataRepository(DocumentDbContext context) : base(context) { }
+}

--- a/src/DocFinder.Services/Repositories/EfRepository.cs
+++ b/src/DocFinder.Services/Repositories/EfRepository.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+/// <summary>
+/// Generic EF Core based repository implementing basic CRUD operations
+/// with filtering, sorting and transaction support.
+/// </summary>
+public class EfRepository<T> : IRepository<T> where T : class
+{
+    protected readonly DocumentDbContext Context;
+
+    public EfRepository(DocumentDbContext context)
+    {
+        Context = context;
+    }
+
+    public async Task<T?> FirstOrDefaultAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default)
+        => await Context.Set<T>().FirstOrDefaultAsync(predicate, ct);
+
+    public async Task<IReadOnlyList<T>> ListAsync(
+        Expression<Func<T, bool>>? filter = null,
+        Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null,
+        CancellationToken ct = default)
+    {
+        IQueryable<T> query = Context.Set<T>();
+        if (filter != null) query = query.Where(filter);
+        if (orderBy != null) query = orderBy(query);
+        return await query.ToListAsync(ct);
+    }
+
+    public async Task AddAsync(T entity, CancellationToken ct = default)
+    {
+        await Context.Set<T>().AddAsync(entity, ct);
+        await Context.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateAsync(T entity, CancellationToken ct = default)
+    {
+        Context.Set<T>().Update(entity);
+        await Context.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteAsync(T entity, CancellationToken ct = default)
+    {
+        Context.Set<T>().Remove(entity);
+        await Context.SaveChangesAsync(ct);
+    }
+
+    public async Task ExecuteInTransactionAsync(Func<CancellationToken, Task> operation, CancellationToken ct = default)
+    {
+        await using var transaction = await Context.Database.BeginTransactionAsync(ct);
+        try
+        {
+            await operation(ct);
+            await transaction.CommitAsync(ct);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(ct);
+            throw;
+        }
+    }
+}

--- a/src/DocFinder.Services/Repositories/FileListItemRepository.cs
+++ b/src/DocFinder.Services/Repositories/FileListItemRepository.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class FileListItemRepository : EfRepository<FileListItem>, IFileListItemRepository
+{
+    public FileListItemRepository(DocumentDbContext context) : base(context) { }
+}

--- a/src/DocFinder.Services/Repositories/FileListRepository.cs
+++ b/src/DocFinder.Services/Repositories/FileListRepository.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class FileListRepository : EfRepository<FileList>, IFileListRepository
+{
+    public FileListRepository(DocumentDbContext context) : base(context) { }
+}

--- a/src/DocFinder.Services/Repositories/FileRepository.cs
+++ b/src/DocFinder.Services/Repositories/FileRepository.cs
@@ -1,0 +1,9 @@
+using FileEntity = DocFinder.Domain.File;
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class FileRepository : EfRepository<FileEntity>, IFileRepository
+{
+    public FileRepository(DocumentDbContext context) : base(context) { }
+}

--- a/src/DocFinder.Services/Repositories/ProtocolListItemRepository.cs
+++ b/src/DocFinder.Services/Repositories/ProtocolListItemRepository.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class ProtocolListItemRepository : EfRepository<ProtocolListItem>, IProtocolListItemRepository
+{
+    public ProtocolListItemRepository(DocumentDbContext context) : base(context) { }
+}

--- a/src/DocFinder.Services/Repositories/ProtocolListRepository.cs
+++ b/src/DocFinder.Services/Repositories/ProtocolListRepository.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class ProtocolListRepository : EfRepository<ProtocolList>, IProtocolListRepository
+{
+    public ProtocolListRepository(DocumentDbContext context) : base(context) { }
+}

--- a/src/DocFinder.Services/Repositories/ProtocolRepository.cs
+++ b/src/DocFinder.Services/Repositories/ProtocolRepository.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class ProtocolRepository : EfRepository<Protocol>, IProtocolRepository
+{
+    public ProtocolRepository(DocumentDbContext context) : base(context) { }
+}


### PR DESCRIPTION
## Summary
- add generic repository interface with filtering, sorting and transaction support
- implement EF Core repository base and entity-specific repositories

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b7d9e724608326a3fbd153d7f5b899