### PR TITLE
Add generic repository command/handler framework

### DIFF
--- a/src/DocFinder.Application/Commands/AddAuditEntryCommand.cs
+++ b/src/DocFinder.Application/Commands/AddAuditEntryCommand.cs
@@ -1,0 +1,5 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Application.Commands;
+
+public sealed record AddAuditEntryCommand(AuditEntry Entity) : AddEntityCommand<AuditEntry>(Entity);

--- a/src/DocFinder.Application/Commands/AddDataCommand.cs
+++ b/src/DocFinder.Application/Commands/AddDataCommand.cs
@@ -1,0 +1,5 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Application.Commands;
+
+public sealed record AddDataCommand(Data Entity) : AddEntityCommand<Data>(Entity);

--- a/src/DocFinder.Application/Commands/AddEntityCommand.cs
+++ b/src/DocFinder.Application/Commands/AddEntityCommand.cs
@@ -1,0 +1,3 @@
+namespace DocFinder.Application.Commands;
+
+public record AddEntityCommand<T>(T Entity) : ICommand<Unit> where T : class;

--- a/src/DocFinder.Application/Commands/AddFileCommand.cs
+++ b/src/DocFinder.Application/Commands/AddFileCommand.cs
@@ -1,0 +1,5 @@
+using FileEntity = DocFinder.Domain.File;
+
+namespace DocFinder.Application.Commands;
+
+public sealed record AddFileCommand(FileEntity Entity) : AddEntityCommand<FileEntity>(Entity);

--- a/src/DocFinder.Application/Commands/AddFileListCommand.cs
+++ b/src/DocFinder.Application/Commands/AddFileListCommand.cs
@@ -1,0 +1,5 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Application.Commands;
+
+public sealed record AddFileListCommand(FileList Entity) : AddEntityCommand<FileList>(Entity);

--- a/src/DocFinder.Application/Commands/AddFileListItemCommand.cs
+++ b/src/DocFinder.Application/Commands/AddFileListItemCommand.cs
@@ -1,0 +1,5 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Application.Commands;
+
+public sealed record AddFileListItemCommand(FileListItem Entity) : AddEntityCommand<FileListItem>(Entity);

--- a/src/DocFinder.Application/Commands/AddProtocolCommand.cs
+++ b/src/DocFinder.Application/Commands/AddProtocolCommand.cs
@@ -1,0 +1,5 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Application.Commands;
+
+public sealed record AddProtocolCommand(Protocol Entity) : AddEntityCommand<Protocol>(Entity);

--- a/src/DocFinder.Application/Commands/AddProtocolListCommand.cs
+++ b/src/DocFinder.Application/Commands/AddProtocolListCommand.cs
@@ -1,0 +1,5 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Application.Commands;
+
+public sealed record AddProtocolListCommand(ProtocolList Entity) : AddEntityCommand<ProtocolList>(Entity);

--- a/src/DocFinder.Application/Commands/AddProtocolListItemCommand.cs
+++ b/src/DocFinder.Application/Commands/AddProtocolListItemCommand.cs
@@ -1,0 +1,5 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Application.Commands;
+
+public sealed record AddProtocolListItemCommand(ProtocolListItem Entity) : AddEntityCommand<ProtocolListItem>(Entity);

--- a/src/DocFinder.Application/DocFinder.Application.csproj
+++ b/src/DocFinder.Application/DocFinder.Application.csproj
@@ -8,5 +8,6 @@
     <ProjectReference Include="../DocFinder.Domain/DocFinder.Domain.csproj" />
     <ProjectReference Include="../DocFinder.Search/DocFinder.Search.csproj" />
     <ProjectReference Include="../DocFinder.Indexing/DocFinder.Indexing.csproj" />
+    <ProjectReference Include="../DocFinder.Services/DocFinder.Services.csproj" />
   </ItemGroup>
 </Project>

--- a/src/DocFinder.Application/Handlers/AddAuditEntryHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddAuditEntryHandler.cs
@@ -1,0 +1,10 @@
+using DocFinder.Application.Commands;
+using DocFinder.Domain;
+using DocFinder.Services;
+
+namespace DocFinder.Application.Handlers;
+
+public sealed class AddAuditEntryHandler : AddEntityHandler<AuditEntry>
+{
+    public AddAuditEntryHandler(AuditEntryService service) : base(service) { }
+}

--- a/src/DocFinder.Application/Handlers/AddDataHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddDataHandler.cs
@@ -1,0 +1,10 @@
+using DocFinder.Application.Commands;
+using DocFinder.Domain;
+using DocFinder.Services;
+
+namespace DocFinder.Application.Handlers;
+
+public sealed class AddDataHandler : AddEntityHandler<Data>
+{
+    public AddDataHandler(DataService service) : base(service) { }
+}

--- a/src/DocFinder.Application/Handlers/AddEntityHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddEntityHandler.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DocFinder.Application.Commands;
+using DocFinder.Services;
+
+namespace DocFinder.Application.Handlers;
+
+public class AddEntityHandler<T> : ICommandHandler<AddEntityCommand<T>, Unit> where T : class
+{
+    private readonly RepositoryService<T> _service;
+
+    public AddEntityHandler(RepositoryService<T> service) => _service = service;
+
+    public async Task<Unit> HandleAsync(AddEntityCommand<T> command, CancellationToken ct)
+    {
+        await _service.AddAsync(command.Entity, ct);
+        return new Unit();
+    }
+}

--- a/src/DocFinder.Application/Handlers/AddFileHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddFileHandler.cs
@@ -1,0 +1,10 @@
+using DocFinder.Application.Commands;
+using DocFinder.Services;
+using FileEntity = DocFinder.Domain.File;
+
+namespace DocFinder.Application.Handlers;
+
+public sealed class AddFileHandler : AddEntityHandler<FileEntity>
+{
+    public AddFileHandler(FileService service) : base(service) { }
+}

--- a/src/DocFinder.Application/Handlers/AddFileListHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddFileListHandler.cs
@@ -1,0 +1,10 @@
+using DocFinder.Application.Commands;
+using DocFinder.Domain;
+using DocFinder.Services;
+
+namespace DocFinder.Application.Handlers;
+
+public sealed class AddFileListHandler : AddEntityHandler<FileList>
+{
+    public AddFileListHandler(FileListService service) : base(service) { }
+}

--- a/src/DocFinder.Application/Handlers/AddFileListItemHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddFileListItemHandler.cs
@@ -1,0 +1,10 @@
+using DocFinder.Application.Commands;
+using DocFinder.Domain;
+using DocFinder.Services;
+
+namespace DocFinder.Application.Handlers;
+
+public sealed class AddFileListItemHandler : AddEntityHandler<FileListItem>
+{
+    public AddFileListItemHandler(FileListItemService service) : base(service) { }
+}

--- a/src/DocFinder.Application/Handlers/AddProtocolHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddProtocolHandler.cs
@@ -1,0 +1,10 @@
+using DocFinder.Application.Commands;
+using DocFinder.Domain;
+using DocFinder.Services;
+
+namespace DocFinder.Application.Handlers;
+
+public sealed class AddProtocolHandler : AddEntityHandler<Protocol>
+{
+    public AddProtocolHandler(ProtocolService service) : base(service) { }
+}

--- a/src/DocFinder.Application/Handlers/AddProtocolListHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddProtocolListHandler.cs
@@ -1,0 +1,10 @@
+using DocFinder.Application.Commands;
+using DocFinder.Domain;
+using DocFinder.Services;
+
+namespace DocFinder.Application.Handlers;
+
+public sealed class AddProtocolListHandler : AddEntityHandler<ProtocolList>
+{
+    public AddProtocolListHandler(ProtocolListService service) : base(service) { }
+}

--- a/src/DocFinder.Application/Handlers/AddProtocolListItemHandler.cs
+++ b/src/DocFinder.Application/Handlers/AddProtocolListItemHandler.cs
@@ -1,0 +1,10 @@
+using DocFinder.Application.Commands;
+using DocFinder.Domain;
+using DocFinder.Services;
+
+namespace DocFinder.Application.Handlers;
+
+public sealed class AddProtocolListItemHandler : AddEntityHandler<ProtocolListItem>
+{
+    public AddProtocolListItemHandler(ProtocolListItemService service) : base(service) { }
+}

--- a/src/DocFinder.Services/EntityServices/AuditEntryService.cs
+++ b/src/DocFinder.Services/EntityServices/AuditEntryService.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class AuditEntryService : RepositoryService<AuditEntry>
+{
+    public AuditEntryService(IAuditEntryRepository repository) : base(repository) { }
+}

--- a/src/DocFinder.Services/EntityServices/DataService.cs
+++ b/src/DocFinder.Services/EntityServices/DataService.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class DataService : RepositoryService<Data>
+{
+    public DataService(IDataRepository repository) : base(repository) { }
+}

--- a/src/DocFinder.Services/EntityServices/FileListItemService.cs
+++ b/src/DocFinder.Services/EntityServices/FileListItemService.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class FileListItemService : RepositoryService<FileListItem>
+{
+    public FileListItemService(IFileListItemRepository repository) : base(repository) { }
+}

--- a/src/DocFinder.Services/EntityServices/FileListService.cs
+++ b/src/DocFinder.Services/EntityServices/FileListService.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class FileListService : RepositoryService<FileList>
+{
+    public FileListService(IFileListRepository repository) : base(repository) { }
+}

--- a/src/DocFinder.Services/EntityServices/FileService.cs
+++ b/src/DocFinder.Services/EntityServices/FileService.cs
@@ -1,0 +1,9 @@
+using DocFinder.Domain;
+using FileEntity = DocFinder.Domain.File;
+
+namespace DocFinder.Services;
+
+public class FileService : RepositoryService<FileEntity>
+{
+    public FileService(IFileRepository repository) : base(repository) { }
+}

--- a/src/DocFinder.Services/EntityServices/ProtocolListItemService.cs
+++ b/src/DocFinder.Services/EntityServices/ProtocolListItemService.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class ProtocolListItemService : RepositoryService<ProtocolListItem>
+{
+    public ProtocolListItemService(IProtocolListItemRepository repository) : base(repository) { }
+}

--- a/src/DocFinder.Services/EntityServices/ProtocolListService.cs
+++ b/src/DocFinder.Services/EntityServices/ProtocolListService.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class ProtocolListService : RepositoryService<ProtocolList>
+{
+    public ProtocolListService(IProtocolListRepository repository) : base(repository) { }
+}

--- a/src/DocFinder.Services/EntityServices/ProtocolService.cs
+++ b/src/DocFinder.Services/EntityServices/ProtocolService.cs
@@ -1,0 +1,8 @@
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class ProtocolService : RepositoryService<Protocol>
+{
+    public ProtocolService(IProtocolRepository repository) : base(repository) { }
+}

--- a/src/DocFinder.Services/EntityServices/RepositoryService.cs
+++ b/src/DocFinder.Services/EntityServices/RepositoryService.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using DocFinder.Domain;
+
+namespace DocFinder.Services;
+
+public class RepositoryService<T> where T : class
+{
+    private readonly IRepository<T> _repository;
+
+    public RepositoryService(IRepository<T> repository) => _repository = repository;
+
+    public Task<T?> FirstOrDefaultAsync(Expression<Func<T, bool>> predicate, CancellationToken ct = default)
+        => _repository.FirstOrDefaultAsync(predicate, ct);
+
+    public Task<IReadOnlyList<T>> ListAsync(
+        Expression<Func<T, bool>>? filter = null,
+        Func<IQueryable<T>, IOrderedQueryable<T>>? orderBy = null,
+        CancellationToken ct = default)
+        => _repository.ListAsync(filter, orderBy, ct);
+
+    public Task AddAsync(T entity, CancellationToken ct = default)
+        => _repository.AddAsync(entity, ct);
+
+    public Task UpdateAsync(T entity, CancellationToken ct = default)
+        => _repository.UpdateAsync(entity, ct);
+
+    public Task DeleteAsync(T entity, CancellationToken ct = default)
+        => _repository.DeleteAsync(entity, ct);
+
+    public Task ExecuteInTransactionAsync(Func<CancellationToken, Task> operation, CancellationToken ct = default)
+        => _repository.ExecuteInTransactionAsync(operation, ct);
+}


### PR DESCRIPTION
## Summary
- add generic `AddEntityCommand` and `AddEntityHandler` for repository operations
- generate specific add commands and handlers for each repository type
- introduce generic `RepositoryService<T>` with per-entity services

## Testing
- `dotnet test --no-build src/DocFinder.Tests/DocFinder.Tests.csproj` *(hangs after skipping tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e1ac24888326aaf04249149e8e52