### PR TITLE
Add protocol management window and cross-navigation from documents

### DIFF
--- a/src/DocFinder.UI/ViewModels/Entities/ProtocolViewModel.cs
+++ b/src/DocFinder.UI/ViewModels/Entities/ProtocolViewModel.cs
@@ -35,6 +35,7 @@ public partial class ProtocolViewModel : ObservableObject
         Contract = protocol.Contract;
         CreatedUtc = protocol.CreatedUtc;
         ModifiedUtc = protocol.ModifiedUtc;
+        FilePath = protocol.File.FilePath;
     }
 
     [ObservableProperty] private Guid _id;
@@ -62,5 +63,7 @@ public partial class ProtocolViewModel : ObservableObject
     [ObservableProperty] private bool _contract;
     [ObservableProperty] private DateTime _createdUtc;
     [ObservableProperty] private DateTime _modifiedUtc;
+
+    public string FilePath { get; }
 }
 

--- a/src/DocFinder.UI/Views/DocumentWindow.xaml
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml
@@ -58,6 +58,11 @@
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
                 </ui:DataGrid.Columns>
+                <ui:DataGrid.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Otevřít protokoly" Click="OpenProtocols_Click"/>
+                    </ContextMenu>
+                </ui:DataGrid.ContextMenu>
             </ui:DataGrid>
         </DockPanel>
     </Grid>

--- a/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/DocumentWindow.xaml.cs
@@ -167,4 +167,13 @@ public partial class DocumentWindow : FluentWindow
             }
         }
     }
+
+    private void OpenProtocols_Click(object sender, RoutedEventArgs e)
+    {
+        if (documentsGrid.SelectedItem is Document doc)
+        {
+            var window = new ProtocolWindow(doc.FileLink);
+            window.Show();
+        }
+    }
 }

--- a/src/DocFinder.UI/Views/ProtocolWindow.xaml
+++ b/src/DocFinder.UI/Views/ProtocolWindow.xaml
@@ -1,0 +1,40 @@
+<ui:FluentWindow x:Class="DocFinder.UI.Views.ProtocolWindow"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+                 Title="Protocols" Width="900" Height="450"
+                 ExtendsContentIntoTitleBar="True"
+                 WindowBackdropType="Mica"
+                 ResizeMode="CanResize">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <ui:TitleBar Grid.Row="0" Title="Protocols" />
+
+        <DockPanel Grid.Row="1">
+            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
+                <ui:TextBox x:Name="TitleFilter" Width="120" Margin="2" PlaceholderText="Title" TextChanged="OnFilterChanged"/>
+                <ui:TextBox x:Name="RefFilter" Width="100" Margin="2" PlaceholderText="Reference" TextChanged="OnFilterChanged"/>
+                <ui:TextBox x:Name="PersonFilter" Width="120" Margin="2" PlaceholderText="Responsible" TextChanged="OnFilterChanged"/>
+            </StackPanel>
+            <ui:DataGrid x:Name="protocolsGrid" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False" IsReadOnly="False"
+                         RowEditEnding="ProtocolsGrid_RowEditEnding">
+                <ui:DataGrid.Columns>
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}"/>
+                    <DataGridTextColumn Header="Reference" Binding="{Binding ReferenceNumber}"/>
+                    <DataGridTextColumn Header="Issued" Binding="{Binding IssuedBy}"/>
+                    <DataGridTextColumn Header="Responsible" Binding="{Binding ResponsiblePerson}"/>
+                    <DataGridTextColumn Header="Date" Binding="{Binding IssueDateUtc}"/>
+                </ui:DataGrid.Columns>
+                <ui:DataGrid.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Open File" Click="OpenFile_Click"/>
+                    </ContextMenu>
+                </ui:DataGrid.ContextMenu>
+            </ui:DataGrid>
+        </DockPanel>
+    </Grid>
+</ui:FluentWindow>

--- a/src/DocFinder.UI/Views/ProtocolWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/ProtocolWindow.xaml.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using DocFinder.Services;
+using DocFinder.Domain;
+using Microsoft.EntityFrameworkCore;
+using Wpf.Ui.Controls;
+using DocFinder.UI.ViewModels.Entities;
+
+namespace DocFinder.UI.Views;
+
+public partial class ProtocolWindow : FluentWindow
+{
+    private readonly DocumentDbContext _context;
+    private readonly ObservableCollection<ProtocolViewModel> _protocols;
+    private readonly ICollectionView _view;
+    private readonly string? _filePathFilter;
+
+    public ProtocolWindow(string? filePathFilter = null, DbContextOptions<DocumentDbContext>? dbOptions = null)
+    {
+        InitializeComponent();
+        _filePathFilter = filePathFilter;
+        _context = dbOptions != null ? new DocumentDbContext(dbOptions) : new DocumentDbContext();
+
+        var query = _context.Protocols.Include(p => p.File).AsQueryable();
+        if (!string.IsNullOrEmpty(_filePathFilter))
+            query = query.Where(p => p.File.FilePath == _filePathFilter);
+
+        _protocols = new ObservableCollection<ProtocolViewModel>(
+            query.AsEnumerable().Select(p => new ProtocolViewModel(p)).ToList());
+        protocolsGrid.ItemsSource = _protocols;
+
+        _view = CollectionViewSource.GetDefaultView(_protocols);
+        _view.Filter = Filter;
+    }
+
+    private bool Filter(object obj)
+    {
+        if (obj is not ProtocolViewModel p) return false;
+        return Match(p.Title, TitleFilter.Text)
+            && Match(p.ReferenceNumber, RefFilter.Text)
+            && Match(p.ResponsiblePerson, PersonFilter.Text);
+    }
+
+    private static bool Match(string? value, string filter)
+        => string.IsNullOrEmpty(filter) || (value?.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0);
+
+    private void OnFilterChanged(object sender, TextChangedEventArgs e) => _view.Refresh();
+
+    private void ProtocolsGrid_RowEditEnding(object sender, DataGridRowEditEndingEventArgs e)
+    {
+        if (e.EditAction != DataGridEditAction.Commit) return;
+        if (e.Row.Item is ProtocolViewModel vm)
+        {
+            var protocol = _context.Protocols.Include(p => p.File).FirstOrDefault(p => p.Id == vm.Id);
+            if (protocol != null)
+            {
+                protocol.SetTitle(vm.Title);
+                protocol.SetReferenceNumber(vm.ReferenceNumber);
+                protocol.SetIssuedBy(vm.IssuedBy);
+                protocol.SetResponsiblePerson(vm.ResponsiblePerson);
+                _context.SaveChanges();
+            }
+        }
+    }
+
+    private void OpenFile_Click(object sender, RoutedEventArgs e)
+    {
+        if (protocolsGrid.SelectedItem is ProtocolViewModel vm && !string.IsNullOrEmpty(vm.FilePath))
+        {
+            if (File.Exists(vm.FilePath))
+            {
+                Process.Start(new ProcessStartInfo(vm.FilePath) { UseShellExecute = true });
+            }
+            else
+            {
+                var messageBox = new MessageBox
+                {
+                    Title = "DocFinder",
+                    Content = "Soubor neexistuje.",
+                    CloseButtonText = "OK"
+                };
+                messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml
@@ -101,6 +101,11 @@
                                     <ui:SymbolIcon Symbol="Document24" />
                                 </MenuItem.Icon>
                             </MenuItem>
+                            <MenuItem Header="Správa protokolů" Click="Menu_Protocols_Click">
+                                <MenuItem.Icon>
+                                    <ui:SymbolIcon Symbol="ClipboardText24" />
+                                </MenuItem.Icon>
+                            </MenuItem>
                             <MenuItem Header="Nastavení…" Click="Menu_Settings_Click">
                                 <MenuItem.Icon>
                                     <ui:SymbolIcon Symbol="Settings28" />

--- a/src/DocFinder.UI/Views/SearchOverlay.xaml.cs
+++ b/src/DocFinder.UI/Views/SearchOverlay.xaml.cs
@@ -91,6 +91,12 @@ public partial class SearchOverlay : FluentWindow
         window.Show();
     }
 
+    private void Menu_Protocols_Click(object sender, RoutedEventArgs e)
+    {
+        var window = new ProtocolWindow();
+        window.Show();
+    }
+
     private async void Menu_Reindex_Click(object sender, RoutedEventArgs e)
     {
         if (!_dialogs.ShowConfirmation("Přeindexovat všechny dokumenty?", "DocFinder"))


### PR DESCRIPTION
## Summary
- expose file path on protocol view models
- add protocol management window with filtering and editing
- link documents and protocols via new context menus and menu item

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8104cb4a48326936da2b037577444