### PR TITLE
Fix WPF resource references and disambiguate MessageBox

### DIFF
--- a/src/DocFinder.App/App.xaml
+++ b/src/DocFinder.App/App.xaml
@@ -11,7 +11,6 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ui:ThemesDictionary Theme="Light" />
-                <ui:ColorsDictionary />
                 <ui:ControlsDictionary />
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/src/DocFinder.UI/Services/MessageDialogService.cs
+++ b/src/DocFinder.UI/Services/MessageDialogService.cs
@@ -1,4 +1,5 @@
-using Wpf.Ui.Controls;
+using MessageBox = Wpf.Ui.Controls.MessageBox;
+using MessageBoxResult = Wpf.Ui.Controls.MessageBoxResult;
 
 namespace DocFinder.UI.Services;
 

--- a/src/DocFinder.UI/Views/ProtocolWindow.xaml.cs
+++ b/src/DocFinder.UI/Views/ProtocolWindow.xaml.cs
@@ -11,6 +11,7 @@ using DocFinder.Domain;
 using Microsoft.EntityFrameworkCore;
 using Wpf.Ui.Controls;
 using DocFinder.UI.ViewModels.Entities;
+using MessageBox = Wpf.Ui.Controls.MessageBox;
 
 namespace DocFinder.UI.Views;
 


### PR DESCRIPTION
## Summary
- remove deprecated ColorsDictionary reference from App.xaml
- alias Wpf.Ui MessageBox to avoid ambiguity with System.Windows

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b8191da6e48326babe6e36cdc28682