### PR TITLE
Fix WPF resource and view model references

### DIFF
--- a/src/DocFinder.App/App.xaml
+++ b/src/DocFinder.App/App.xaml
@@ -9,6 +9,8 @@
     ShutdownMode="OnExplicitShutdown">
     <Application.Resources>
         <ResourceDictionary>
+            <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="Black" />
+            <SolidColorBrush x:Key="ControlStrokeColorDefaultBrush" Color="#FFABADB3" />
             <ResourceDictionary.MergedDictionaries>
                 <ui:ThemesDictionary Theme="Light" />
                 <ui:ControlsDictionary />

--- a/src/DocFinder.App/Views/Pages/DashboardPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DashboardPage.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:DocFinder.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
     Title="DashboardPage"
     d:DataContext="{d:DesignInstance vm:DashboardViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.App/Views/Pages/DataPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DataPage.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="clr-namespace:DocFinder.Models"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
     Title="DataPage"
     d:DataContext="{d:DesignInstance vm:DataViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.App/Views/Pages/FilesPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FilesPage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:DocFinder.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
     Title="FilesPage"
     d:DataContext="{d:DesignInstance vm:FilesViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:DocFinder.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
     Title="ProtocolsPage"
     d:DataContext="{d:DesignInstance vm:ProtocolsViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.App/Views/Pages/SettingsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SettingsPage.xaml
@@ -7,7 +7,7 @@
     xmlns:local="clr-namespace:DocFinder.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
     Title="SettingsPage"
     d:DataContext="{d:DesignInstance vm:SettingsViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.Services/SettingsService.cs
+++ b/src/DocFinder.Services/SettingsService.cs
@@ -87,7 +87,7 @@ public sealed class SettingsService : ISettingsService
         return new AppSettings
         {
             SourceRoot = loaded.SourceRoot ?? d.SourceRoot,
-            WatchedRoots = loaded.WatchedRoots != null ? new List<string>(loaded.WatchedRoots) : new List<string>(d.WatchedRoots),
+            WatchedRoots = loaded.WatchedRoots?.ToList() ?? new(d.WatchedRoots),
             EnableOcr = loaded.EnableOcr,
             Theme = loaded.Theme ?? d.Theme,
             AutoIndexOnStartup = loaded.AutoIndexOnStartup,

--- a/src/DocFinder.UI/ViewModels/SettingsViewModel.cs
+++ b/src/DocFinder.UI/ViewModels/SettingsViewModel.cs
@@ -54,7 +54,8 @@ public partial class SettingsViewModel : ObservableObject
         _watcherService.UpdateRoots(Settings.WatchedRoots);
 
         // Apply the selected theme immediately
-        var theme = Settings.Theme.Equals("Dark", StringComparison.OrdinalIgnoreCase)
+        var themeName = string.IsNullOrWhiteSpace(Settings.Theme) ? "Light" : Settings.Theme;
+        var theme = themeName.Equals("Dark", StringComparison.OrdinalIgnoreCase)
             ? ApplicationTheme.Dark
             : ApplicationTheme.Light;
         ApplicationThemeManager.Apply(theme);


### PR DESCRIPTION
## Summary
- Add fallback brushes for TextFillColorPrimaryBrush and ControlStrokeColorDefaultBrush
- Include assembly name when referencing page view models
- Simplify settings merge and guard theme selection

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81bd529588326bae27b937e52296f