### PR TITLE
fix: remove redundant assembly qualifiers from viewmodel namespaces

### DIFF
--- a/src/DocFinder.App/Views/Pages/DashboardPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DashboardPage.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:DocFinder.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
     Title="DashboardPage"
     d:DataContext="{d:DesignInstance vm:DashboardViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.App/Views/Pages/DataPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DataPage.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="clr-namespace:DocFinder.Models"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
     Title="DataPage"
     d:DataContext="{d:DesignInstance vm:DataViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.App/Views/Pages/FilesPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FilesPage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:DocFinder.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
     Title="FilesPage"
     d:DataContext="{d:DesignInstance vm:FilesViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:local="clr-namespace:DocFinder.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
     Title="ProtocolsPage"
     d:DataContext="{d:DesignInstance vm:ProtocolsViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"

--- a/src/DocFinder.App/Views/Pages/SettingsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SettingsPage.xaml
@@ -7,7 +7,7 @@
     xmlns:local="clr-namespace:DocFinder.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages;assembly=DocFinder.App"
+    xmlns:vm="clr-namespace:DocFinder.ViewModels.Pages"
     Title="SettingsPage"
     d:DataContext="{d:DesignInstance vm:SettingsViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"


### PR DESCRIPTION
## Summary
- remove redundant assembly qualifiers in view model XML namespaces

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b81ea6d2448326a83e42c47fe71602