### PR TITLE
Fix invalid clipboard icon in menu

### DIFF
--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -98,7 +98,7 @@
                             </MenuItem>
                             <MenuItem Header="Správa protokolů" Click="Menu_Protocols_Click">
                                 <MenuItem.Icon>
-                                    <ui:SymbolIcon Symbol="ClipboardText24" />
+                                    <ui:SymbolIcon Symbol="ClipboardTextLtr24" />
                                 </MenuItem.Icon>
                             </MenuItem>
                             <MenuItem Header="Nastavení…" Click="Menu_Settings_Click">


### PR DESCRIPTION
## Summary
- use ClipboardTextLtr24 symbol to avoid invalid value

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8333026908326b99ffdafdcf32540