### PR TITLE
Use async file reading in catalog repository

### DIFF
--- a/src/DocFinder.Catalog/CatalogRepository.cs
+++ b/src/DocFinder.Catalog/CatalogRepository.cs
@@ -31,7 +31,7 @@ public sealed class CatalogRepository
         await using var db = new DocumentDbContext(_options);
         var entity = await db.Files.Include(f => f.Data)
             .FirstOrDefaultAsync(f => f.FileId == doc.FileId, ct);
-        var bytes = System.IO.File.ReadAllBytes(doc.Path);
+        var bytes = await System.IO.File.ReadAllBytesAsync(doc.Path, ct);
 
         if (entity is null)
         {


### PR DESCRIPTION
## Summary
- use `File.ReadAllBytesAsync` in `UpsertFileAsync` to avoid blocking threads when reading file contents

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_68b84f5e6ec4832688b24026e8606579