### PR TITLE
Ensure file identity based on content hash

### DIFF
--- a/src/DocFinder.Indexing/DocumentIndexer.cs
+++ b/src/DocFinder.Indexing/DocumentIndexer.cs
@@ -72,7 +72,7 @@ public sealed class DocumentIndexer : IIndexer
         if (meta.Modified.HasValue) modified = meta.Modified.Value.UtcDateTime;
 
         var sha = ComputeSha256(path);
-        var fileId = ComputeFileId(path, sha);
+        var fileId = ComputeFileId(sha);
         var metaDict = new Dictionary<string,string>();
         if (!string.IsNullOrEmpty(author)) metaDict["author"] = author;
         if (!string.IsNullOrEmpty(version)) metaDict["version"] = version;
@@ -142,7 +142,7 @@ public sealed class DocumentIndexer : IIndexer
         {
             using var stream = System.IO.File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             var hash = SHA256.HashData(stream);
-            return Convert.ToHexString(hash);
+            return Convert.ToHexString(hash).ToLowerInvariant();
         }
         catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
         {
@@ -151,9 +151,9 @@ public sealed class DocumentIndexer : IIndexer
         return string.Empty;
     }
 
-    private static Guid ComputeFileId(string path, string sha)
+    private static Guid ComputeFileId(string sha)
     {
-        var bytes = Encoding.UTF8.GetBytes(path + sha);
+        var bytes = Encoding.UTF8.GetBytes(sha);
         var hash = SHA256.HashData(bytes);
         Span<byte> guidBytes = stackalloc byte[16];
         hash.AsSpan(0, 16).CopyTo(guidBytes);


### PR DESCRIPTION
## Summary
- compute file IDs solely from SHA-256 hash
- normalize computed SHA-256 to lowercase for consistent comparisons

## Testing
- `dotnet build src/DocFinder.Indexing/DocFinder.Indexing.csproj -c Debug`
- `dotnet build src/DocFinder.Tests/DocFinder.Tests.csproj -c Debug`
- ⚠️ `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj -c Debug` *(hangs after executing skipped tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b85474211c8326a8f39885698137ad