### PR TITLE
Add configurable page size for searches

### DIFF
--- a/src/DocFinder.App/ViewModels/Entities/AppSettingsViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Entities/AppSettingsViewModel.cs
@@ -14,6 +14,7 @@ public partial class AppSettingsViewModel : ObservableObject
         Theme = settings.Theme;
         AutoIndexOnStartup = settings.AutoIndexOnStartup;
         UseFuzzySearch = settings.UseFuzzySearch;
+        PageSize = settings.PageSize;
         PollingMinutes = settings.PollingMinutes;
         IndexPath = settings.IndexPath;
         ThumbsPath = settings.ThumbsPath;
@@ -25,6 +26,7 @@ public partial class AppSettingsViewModel : ObservableObject
     [ObservableProperty] private string _theme = "Light";
     [ObservableProperty] private bool _autoIndexOnStartup = true;
     [ObservableProperty] private bool _useFuzzySearch;
+    [ObservableProperty] private int _pageSize = 20;
     [ObservableProperty] private int _pollingMinutes = 5;
     [ObservableProperty] private string? _indexPath;
     [ObservableProperty] private string? _thumbsPath;

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
@@ -34,6 +34,8 @@
             </ComboBox>
             <CheckBox Content="Auto index on startup" IsChecked="{Binding Settings.AutoIndexOnStartup}"/>
             <CheckBox Content="Use fuzzy search" IsChecked="{Binding Settings.UseFuzzySearch}"/>
+            <TextBlock Margin="0,12,0,0" Text="Page Size"/>
+            <TextBox Text="{Binding Settings.PageSize, UpdateSourceTrigger=PropertyChanged}"/>
             <Button Content="Save" Command="{Binding SaveCommand}" Margin="0,20,0,0"/>
 
             <DataGrid ItemsSource="{Binding IndexedFiles}" Margin="0,20,0,0" Height="150" AutoGenerateColumns="False">

--- a/src/DocFinder.Application/Handlers/SearchDocumentsHandler.cs
+++ b/src/DocFinder.Application/Handlers/SearchDocumentsHandler.cs
@@ -4,13 +4,19 @@ using System.Threading;
 using System.Threading.Tasks;
 using DocFinder.Application.Commands;
 using DocFinder.Domain;
+using DocFinder.Domain.Settings;
 
 namespace DocFinder.Application.Handlers;
 
 public sealed class SearchDocumentsHandler : ICommandHandler<SearchDocumentsCommand, SearchResult>
 {
     private readonly ISearchService _search;
-    public SearchDocumentsHandler(ISearchService search) => _search = search;
+    private readonly ISettingsService _settings;
+    public SearchDocumentsHandler(ISearchService search, ISettingsService settings)
+    {
+        _search = search;
+        _settings = settings;
+    }
 
     public async Task<SearchResult> HandleAsync(SearchDocumentsCommand command, CancellationToken ct)
     {
@@ -26,7 +32,8 @@ public sealed class SearchDocumentsHandler : ICommandHandler<SearchDocumentsComm
         {
             Filters = filters,
             FromUtc = command.Filter.FromDate.HasValue ? new DateTimeOffset(command.Filter.FromDate.Value.ToUniversalTime()) : null,
-            ToUtc = command.Filter.ToDate.HasValue ? new DateTimeOffset(command.Filter.ToDate.Value.ToUniversalTime()) : null
+            ToUtc = command.Filter.ToDate.HasValue ? new DateTimeOffset(command.Filter.ToDate.Value.ToUniversalTime()) : null,
+            PageSize = _settings.Current.PageSize
         };
 
         return await _search.QueryAsync(query, ct);

--- a/src/DocFinder.Domain/Settings/AppSettings.cs
+++ b/src/DocFinder.Domain/Settings/AppSettings.cs
@@ -28,6 +28,9 @@ public sealed class AppSettings
     /// <summary>Use fuzzy search when querying the index.</summary>
     public bool UseFuzzySearch { get; set; } = false;
 
+    /// <summary>Number of search results returned per page.</summary>
+    public int PageSize { get; set; } = 20;
+
     /// <summary>Frequency in minutes the file system is polled for changes.</summary>
     public int PollingMinutes { get; set; } = 5;
 

--- a/src/DocFinder.Services/SettingsService.cs
+++ b/src/DocFinder.Services/SettingsService.cs
@@ -92,6 +92,7 @@ public sealed class SettingsService : ISettingsService
             Theme = loaded.Theme ?? d.Theme,
             AutoIndexOnStartup = loaded.AutoIndexOnStartup,
             UseFuzzySearch = loaded.UseFuzzySearch,
+            PageSize = loaded.PageSize == 0 ? d.PageSize : loaded.PageSize,
             PollingMinutes = loaded.PollingMinutes == 0 ? d.PollingMinutes : loaded.PollingMinutes,
             IndexPath = loaded.IndexPath ?? d.IndexPath,
             ThumbsPath = loaded.ThumbsPath ?? d.ThumbsPath

--- a/src/DocFinder.Tests/LuceneSearchServiceTests.cs
+++ b/src/DocFinder.Tests/LuceneSearchServiceTests.cs
@@ -41,4 +41,19 @@ public class LuceneSearchServiceTests
         var result = await service.QueryAsync(new UserQuery("prilis zlutoucky kun"));
         Assert.Equal(1, result.Total);
     }
+
+    [Fact]
+    public async Task QueryHonorsPageSize()
+    {
+        using var service = new LuceneSearchService(new RAMDirectory());
+        for (var i = 0; i < 5; i++)
+        {
+            await service.IndexAsync(new IndexDocument(Guid.NewGuid(), $"/{i}.txt", $"{i}.txt", "txt", 1, DateTime.UtcNow, DateTime.UtcNow, "hash", null, null, "hello", new Dictionary<string, string>()));
+        }
+
+        var result = await service.QueryAsync(new UserQuery("hello") { PageSize = 2 });
+
+        Assert.Equal(5, result.Total);
+        Assert.Equal(2, result.Hits.Count);
+    }
 }

--- a/src/DocFinder.Tests/SearchDocumentsHandlerTests.cs
+++ b/src/DocFinder.Tests/SearchDocumentsHandlerTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DocFinder.Application.Commands;
+using DocFinder.Application.Handlers;
+using DocFinder.Domain;
+using DocFinder.Domain.Settings;
+using Xunit;
+
+namespace DocFinder.Tests;
+
+public class SearchDocumentsHandlerTests
+{
+    private sealed class FakeSearchService : ISearchService
+    {
+        public UserQuery? ReceivedQuery { get; private set; }
+
+        public Task IndexAsync(IndexDocument doc, CancellationToken ct = default) => Task.CompletedTask;
+        public Task DeleteByFileIdAsync(Guid fileId, CancellationToken ct = default) => Task.CompletedTask;
+
+        public ValueTask<SearchResult> QueryAsync(UserQuery query, CancellationToken ct = default)
+        {
+            ReceivedQuery = query;
+            return new ValueTask<SearchResult>(new SearchResult(0, new List<SearchHit>(), new Dictionary<string, int>()));
+        }
+
+        public Task OptimizeAsync(CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class FakeSettingsService : ISettingsService
+    {
+        public FakeSettingsService(int pageSize) => Current = new AppSettings { PageSize = pageSize };
+        public AppSettings Current { get; private set; }
+        public Task<AppSettings> LoadAsync(CancellationToken ct = default) => Task.FromResult(Current);
+        public Task SaveAsync(AppSettings settings, CancellationToken ct = default)
+        {
+            Current = settings;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task HandlerUsesConfiguredPageSize()
+    {
+        var search = new FakeSearchService();
+        var settings = new FakeSettingsService(7);
+        var handler = new SearchDocumentsHandler(search, settings);
+
+        await handler.HandleAsync(new SearchDocumentsCommand("q", new SearchFilter()), CancellationToken.None);
+
+        Assert.Equal(7, search.ReceivedQuery?.PageSize);
+    }
+}
+

--- a/src/DocFinder.Tests/SettingsServiceTests.cs
+++ b/src/DocFinder.Tests/SettingsServiceTests.cs
@@ -31,6 +31,7 @@ public class SettingsServiceTests
         Assert.Equal("Light", loaded.Theme);
         Assert.False(loaded.EnableOcr);
         Assert.Empty(loaded.WatchedRoots);
+        Assert.Equal(20, loaded.PageSize);
     }
 
     [Fact]
@@ -46,6 +47,7 @@ public class SettingsServiceTests
         Assert.True(loaded.EnableOcr);
         // Theme was missing in file so default should be applied
         Assert.Equal("Light", loaded.Theme);
+        Assert.Equal(20, loaded.PageSize);
     }
 
     [Fact]
@@ -53,7 +55,7 @@ public class SettingsServiceTests
     {
         var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "settings.json");
         var service = new SettingsService(temp);
-        var settings = new AppSettings { Theme = "Dark", EnableOcr = true, WatchedRoots = { "/a" } };
+        var settings = new AppSettings { Theme = "Dark", EnableOcr = true, WatchedRoots = { "/a" }, PageSize = 42 };
         await service.SaveAsync(settings);
 
         var service2 = new SettingsService(temp);
@@ -62,6 +64,7 @@ public class SettingsServiceTests
         Assert.Equal("Dark", loaded.Theme);
         Assert.True(loaded.EnableOcr);
         Assert.Contains("/a", loaded.WatchedRoots);
+        Assert.Equal(42, loaded.PageSize);
     }
 
     [Fact]
@@ -69,11 +72,12 @@ public class SettingsServiceTests
     {
         var temp = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), "settings.json");
         var service = new SettingsService(temp);
-        await service.SaveAsync(new AppSettings { Theme = "Dark" });
+        await service.SaveAsync(new AppSettings { Theme = "Dark", PageSize = 30 });
         await service.SaveAsync(new AppSettings()); // reset
 
         var service2 = new SettingsService(temp);
         var loaded = await service2.LoadAsync();
         Assert.Equal("Light", loaded.Theme);
+        Assert.Equal(20, loaded.PageSize);
     }
 }


### PR DESCRIPTION
## Summary
- add `PageSize` to application settings and propagate into search handler
- expose page size in settings UI and view models
- cover page size with unit tests

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj -v normal`

------
https://chatgpt.com/codex/tasks/task_e_68b890bf8a8083269023a779b775552a