### PR TITLE
Enable context menu actions for search results

### DIFF
--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -182,8 +182,9 @@
                               Loaded="ResultsGrid_Loaded"
                               PreviewMouseRightButtonDown="ResultsGrid_PreviewMouseRightButtonDown">
                     <ui:DataGrid.ContextMenu>
-                        <ContextMenu>
+                        <ContextMenu Opening="ResultsGrid_ContextMenu_Opening">
                             <MenuItem Header="Otevřít protokol" Click="OpenProtocol_Click" />
+                            <MenuItem Header="Otevřít detail souboru" Click="OpenFileDetail_Click" />
                         </ContextMenu>
                     </ui:DataGrid.ContextMenu>
                     <ui:DataGrid.Columns>


### PR DESCRIPTION
## Summary
- add context menu with "Otevřít protokol" and "Otevřít detail souboru" actions in search results grid
- enable or disable actions based on selected file type and presence
- show basic file information when opening file detail

## Testing
- `dotnet test -v q` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b916f666e48326ae2399bbe7a45a6c