### PR TITLE
Load theme resources and fix context menu event

### DIFF
--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -16,6 +16,8 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/DocFinder.App;component/Resources/DesignTokens.xaml" />
+                <!-- Include a default theme dictionary so design-time resources are available -->
+                <ResourceDictionary Source="/DocFinder.App;component/Resources/Theme.Light.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <converters:FileSizeConverter x:Key="FileSizeConverter" />
             <converters:UtcToLocalConverter x:Key="UtcToLocalConverter" />
@@ -182,7 +184,7 @@
                               Loaded="ResultsGrid_Loaded"
                               PreviewMouseRightButtonDown="ResultsGrid_PreviewMouseRightButtonDown">
                     <ui:DataGrid.ContextMenu>
-                        <ContextMenu Opening="ResultsGrid_ContextMenu_Opening">
+                        <ContextMenu Opened="ResultsGrid_ContextMenu_Opened">
                             <MenuItem Header="Otevřít protokol" Click="OpenProtocol_Click" />
                             <MenuItem Header="Otevřít detail souboru" Click="OpenFileDetail_Click" />
                         </ContextMenu>

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
@@ -33,6 +33,9 @@ public partial class SearchOverlay : FluentWindow
         _dialogs = dialogs;
 
         InitializeComponent();
+        // Capture the initial theme dictionary merged in XAML so it can be replaced later
+        _themeDictionary = Resources.MergedDictionaries
+            .FirstOrDefault(rd => rd.Source?.OriginalString.Contains("Theme.Light.xaml") == true);
         ApplyTheme(ApplicationThemeManager.GetAppTheme());
         ApplicationThemeManager.Changed += OnThemeChanged;
         SystemThemeWatcher.Watch(this);
@@ -151,7 +154,7 @@ public partial class SearchOverlay : FluentWindow
         window.Show();
     }
 
-    private void ResultsGrid_ContextMenu_Opening(object sender, ContextMenuEventArgs e)
+    private void ResultsGrid_ContextMenu_Opened(object sender, RoutedEventArgs e)
     {
         if (sender is not ContextMenu menu)
             return;


### PR DESCRIPTION
## Summary
- merge the default light theme so XAML resources like AccentBrush resolve at design time
- capture and replace the initial theme dictionary in code
- handle context menu opening via the proper `Opened` event

## Testing
- ⚠️ `dotnet test` *(dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf70051dc8326b427e71c4f97d4f4