### PR TITLE
Integrate protocol management into search overlay

### DIFF
--- a/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml
+++ b/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml
@@ -1,0 +1,27 @@
+<UserControl x:Class="DocFinder.App.Views.Controls.ProtocolListControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
+            <ui:TextBox x:Name="TitleFilter" Width="120" Margin="2" PlaceholderText="Title" TextChanged="OnFilterChanged"/>
+            <ui:TextBox x:Name="RefFilter" Width="100" Margin="2" PlaceholderText="Reference" TextChanged="OnFilterChanged"/>
+            <ui:TextBox x:Name="PersonFilter" Width="120" Margin="2" PlaceholderText="Responsible" TextChanged="OnFilterChanged"/>
+        </StackPanel>
+        <ui:DataGrid x:Name="protocolsGrid" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False" IsReadOnly="False"
+                     RowEditEnding="ProtocolsGrid_RowEditEnding">
+            <ui:DataGrid.Columns>
+                <DataGridTextColumn Header="Title" Binding="{Binding Title}"/>
+                <DataGridTextColumn Header="Reference" Binding="{Binding ReferenceNumber}"/>
+                <DataGridTextColumn Header="Issued" Binding="{Binding IssuedBy}"/>
+                <DataGridTextColumn Header="Responsible" Binding="{Binding ResponsiblePerson}"/>
+                <DataGridTextColumn Header="Date" Binding="{Binding IssueDateUtc}"/>
+            </ui:DataGrid.Columns>
+            <ui:DataGrid.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Open File" Click="OpenFile_Click"/>
+                </ContextMenu>
+            </ui:DataGrid.ContextMenu>
+        </ui:DataGrid>
+    </DockPanel>
+</UserControl>

--- a/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml.cs
+++ b/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using DocFinder.Services;
+using DocFinder.Domain;
+using Microsoft.EntityFrameworkCore;
+using DocFinder.App.ViewModels.Entities;
+using Wpf.Ui.Controls;
+
+namespace DocFinder.App.Views.Controls;
+
+public partial class ProtocolListControl : UserControl
+{
+    private readonly DocumentDbContext _context;
+    private readonly ObservableCollection<ProtocolViewModel> _protocols = new();
+    private readonly ICollectionView _view;
+    private string? _filePathFilter;
+
+    public ProtocolListControl()
+    {
+        InitializeComponent();
+        _context = new DocumentDbContext();
+        protocolsGrid.ItemsSource = _protocols;
+        _view = CollectionViewSource.GetDefaultView(_protocols);
+        _view.Filter = Filter;
+        LoadProtocols();
+    }
+
+    private void LoadProtocols()
+    {
+        var query = _context.Protocols.Include(p => p.File).AsQueryable();
+        if (!string.IsNullOrEmpty(_filePathFilter))
+            query = query.Where(p => p.File.FilePath == _filePathFilter);
+        _protocols.Clear();
+        foreach (var p in query.AsEnumerable().Select(p => new ProtocolViewModel(p)))
+            _protocols.Add(p);
+    }
+
+    public void FilterByPath(string? filePath)
+    {
+        _filePathFilter = filePath;
+        LoadProtocols();
+    }
+
+    private bool Filter(object obj)
+    {
+        if (obj is not ProtocolViewModel p) return false;
+        return Match(p.Title, TitleFilter.Text)
+            && Match(p.ReferenceNumber, RefFilter.Text)
+            && Match(p.ResponsiblePerson, PersonFilter.Text);
+    }
+
+    private static bool Match(string? value, string filter)
+        => string.IsNullOrEmpty(filter) || (value?.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0);
+
+    private void OnFilterChanged(object sender, TextChangedEventArgs e) => _view.Refresh();
+
+    private void ProtocolsGrid_RowEditEnding(object sender, DataGridRowEditEndingEventArgs e)
+    {
+        if (e.EditAction != DataGridEditAction.Commit) return;
+        if (e.Row.Item is ProtocolViewModel vm)
+        {
+            var protocol = _context.Protocols.Include(p => p.File).FirstOrDefault(p => p.Id == vm.Id);
+            if (protocol != null)
+            {
+                protocol.SetTitle(vm.Title);
+                protocol.SetReferenceNumber(vm.ReferenceNumber);
+                protocol.SetIssuedBy(vm.IssuedBy);
+                protocol.SetResponsiblePerson(vm.ResponsiblePerson);
+                _context.SaveChanges();
+            }
+        }
+    }
+
+    private void OpenFile_Click(object sender, RoutedEventArgs e)
+    {
+        if (protocolsGrid.SelectedItem is ProtocolViewModel vm && !string.IsNullOrEmpty(vm.FilePath))
+        {
+            if (System.IO.File.Exists(vm.FilePath))
+            {
+                Process.Start(new ProcessStartInfo(vm.FilePath) { UseShellExecute = true });
+            }
+            else
+            {
+                var messageBox = new MessageBox
+                {
+                    Title = "DocFinder",
+                    Content = "Soubor neexistuje.",
+                    CloseButtonText = "OK",
+                };
+                messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/src/DocFinder.App/Views/Windows/ProtocolWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/ProtocolWindow.xaml
@@ -2,39 +2,10 @@
                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                  xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+                 xmlns:controls="clr-namespace:DocFinder.App.Views.Controls"
                  Title="Protocols" Width="900" Height="450"
                  ExtendsContentIntoTitleBar="True"
                  WindowBackdropType="Mica"
                  ResizeMode="CanResize">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
-
-        <ui:TitleBar Grid.Row="0" Title="Protocols" />
-
-        <DockPanel Grid.Row="1">
-            <StackPanel Orientation="Horizontal" DockPanel.Dock="Top">
-                <ui:TextBox x:Name="TitleFilter" Width="120" Margin="2" PlaceholderText="Title" TextChanged="OnFilterChanged"/>
-                <ui:TextBox x:Name="RefFilter" Width="100" Margin="2" PlaceholderText="Reference" TextChanged="OnFilterChanged"/>
-                <ui:TextBox x:Name="PersonFilter" Width="120" Margin="2" PlaceholderText="Responsible" TextChanged="OnFilterChanged"/>
-            </StackPanel>
-            <ui:DataGrid x:Name="protocolsGrid" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="False" IsReadOnly="False"
-                         RowEditEnding="ProtocolsGrid_RowEditEnding">
-                <ui:DataGrid.Columns>
-                    <DataGridTextColumn Header="Title" Binding="{Binding Title}"/>
-                    <DataGridTextColumn Header="Reference" Binding="{Binding ReferenceNumber}"/>
-                    <DataGridTextColumn Header="Issued" Binding="{Binding IssuedBy}"/>
-                    <DataGridTextColumn Header="Responsible" Binding="{Binding ResponsiblePerson}"/>
-                    <DataGridTextColumn Header="Date" Binding="{Binding IssueDateUtc}"/>
-                </ui:DataGrid.Columns>
-                <ui:DataGrid.ContextMenu>
-                    <ContextMenu>
-                        <MenuItem Header="Open File" Click="OpenFile_Click"/>
-                    </ContextMenu>
-                </ui:DataGrid.ContextMenu>
-            </ui:DataGrid>
-        </DockPanel>
-    </Grid>
+    <controls:ProtocolListControl x:Name="ProtocolList" />
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/ProtocolWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/ProtocolWindow.xaml.cs
@@ -1,93 +1,13 @@
-using System;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Linq;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using DocFinder.Services;
-using DocFinder.Domain;
-using Microsoft.EntityFrameworkCore;
 using Wpf.Ui.Controls;
-using DocFinder.App.ViewModels.Entities;
-using MessageBox = Wpf.Ui.Controls.MessageBox;
 
 namespace DocFinder.App.Views.Windows;
 
 public partial class ProtocolWindow : FluentWindow
 {
-    private readonly DocumentDbContext _context;
-    private readonly ObservableCollection<ProtocolViewModel> _protocols;
-    private readonly ICollectionView _view;
-    private readonly string? _filePathFilter;
-
-    public ProtocolWindow(string? filePathFilter = null, DbContextOptions<DocumentDbContext>? dbOptions = null)
+    public ProtocolWindow(string? filePathFilter = null)
     {
         InitializeComponent();
-        _filePathFilter = filePathFilter;
-        _context = dbOptions != null ? new DocumentDbContext(dbOptions) : new DocumentDbContext();
-
-        var query = _context.Protocols.Include(p => p.File).AsQueryable();
-        if (!string.IsNullOrEmpty(_filePathFilter))
-            query = query.Where(p => p.File.FilePath == _filePathFilter);
-
-        _protocols = new ObservableCollection<ProtocolViewModel>(
-            query.AsEnumerable().Select(p => new ProtocolViewModel(p)).ToList());
-        protocolsGrid.ItemsSource = _protocols;
-
-        _view = CollectionViewSource.GetDefaultView(_protocols);
-        _view.Filter = Filter;
-    }
-
-    private bool Filter(object obj)
-    {
-        if (obj is not ProtocolViewModel p) return false;
-        return Match(p.Title, TitleFilter.Text)
-            && Match(p.ReferenceNumber, RefFilter.Text)
-            && Match(p.ResponsiblePerson, PersonFilter.Text);
-    }
-
-    private static bool Match(string? value, string filter)
-        => string.IsNullOrEmpty(filter) || (value?.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0);
-
-    private void OnFilterChanged(object sender, TextChangedEventArgs e) => _view.Refresh();
-
-    private void ProtocolsGrid_RowEditEnding(object sender, DataGridRowEditEndingEventArgs e)
-    {
-        if (e.EditAction != DataGridEditAction.Commit) return;
-        if (e.Row.Item is ProtocolViewModel vm)
-        {
-            var protocol = _context.Protocols.Include(p => p.File).FirstOrDefault(p => p.Id == vm.Id);
-            if (protocol != null)
-            {
-                protocol.SetTitle(vm.Title);
-                protocol.SetReferenceNumber(vm.ReferenceNumber);
-                protocol.SetIssuedBy(vm.IssuedBy);
-                protocol.SetResponsiblePerson(vm.ResponsiblePerson);
-                _context.SaveChanges();
-            }
-        }
-    }
-
-    private void OpenFile_Click(object sender, RoutedEventArgs e)
-    {
-        if (protocolsGrid.SelectedItem is ProtocolViewModel vm && !string.IsNullOrEmpty(vm.FilePath))
-        {
-            if (System.IO.File.Exists(vm.FilePath))
-            {
-                Process.Start(new ProcessStartInfo(vm.FilePath) { UseShellExecute = true });
-            }
-            else
-            {
-                var messageBox = new MessageBox
-                {
-                    Title = "DocFinder",
-                    Content = "Soubor neexistuje.",
-                    CloseButtonText = "OK"
-                };
-                messageBox.ShowDialogAsync().GetAwaiter().GetResult();
-            }
-        }
+        ProtocolList.FilterByPath(filePathFilter);
     }
 }

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:converters="clr-namespace:DocFinder.App.Converters"
+    xmlns:controls="clr-namespace:DocFinder.App.Views.Controls"
     Title="DocFinder" Width="900" Height="520"
     FontSize="{DynamicResource BodyFontSize}"
     WindowStartupLocation="CenterScreen"
@@ -71,145 +72,152 @@
 
         <ui:TitleBar Grid.Row="0" Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}" />
 
-        <Grid Grid.Row="1" Margin="{StaticResource Space24}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-
-            <!-- Search bar -->
-            <Grid Grid.Row="0" Margin="{StaticResource MarginBottomSpace16}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="Auto"/>
-                </Grid.ColumnDefinitions>
-
-                <ui:Button x:Name="MenuButton" Grid.Column="0" Style="{StaticResource IconButtonStyle}" ToolTip="Menu" Click="MenuButton_Click">
-                    <ui:Button.Icon>
-                        <ui:SymbolIcon Symbol="Navigation16" FontSize="{StaticResource IconSize}" />
-                    </ui:Button.Icon>
-                    <ui:Button.ContextMenu>
-                        <ContextMenu>
-                            <MenuItem Header="Nové hledání" Click="Menu_NewSearch_Click">
-                                <MenuItem.Icon>
-                                    <ui:SymbolIcon Symbol="Search28" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Header="Správa protokolů" Click="Menu_Protocols_Click">
-                                <MenuItem.Icon>
-                                    <ui:SymbolIcon Symbol="ClipboardTextLtr24" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Header="Nastavení…" Click="Menu_Settings_Click">
-                                <MenuItem.Icon>
-                                    <ui:SymbolIcon Symbol="Settings28" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Header="Přeindexovat" Click="Menu_Reindex_Click">
-                                <MenuItem.Icon>
-                                    <ui:SymbolIcon Symbol="ArrowClockwise28" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem x:Name="PauseResumeMenuItem" Header="Pozastavit indexaci" Click="Menu_PauseResume_Click">
-                                <MenuItem.Icon>
-                                    <ui:SymbolIcon x:Name="PauseResumeIcon" Symbol="PauseCircle24" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                            <MenuItem Header="Ukončit" Click="Menu_Exit_Click">
-                                <MenuItem.Icon>
-                                    <ui:SymbolIcon Symbol="Dismiss28" />
-                                </MenuItem.Icon>
-                            </MenuItem>
-                        </ContextMenu>
-                    </ui:Button.ContextMenu>
-                </ui:Button>
-
-                <ui:TextBox x:Name="QueryTextBox" Grid.Column="1" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}"
-                            Text="{Binding Query, UpdateSourceTrigger=PropertyChanged}" Padding="{StaticResource Space12}"
-                            PlaceholderEnabled="True" PlaceholderText="Hledat…"/>
-
-                <ComboBox Grid.Column="2" SelectedValuePath="Tag" SelectedValue="{Binding FileTypeFilter}"
-                          Width="100" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}">
-                    <ComboBoxItem Content="Vše" Tag="all" />
-                    <ComboBoxItem Content="PDF" Tag="pdf" />
-                    <ComboBoxItem Content="DOCX" Tag="docx" />
-                </ComboBox>
-
-                <ui:Button Grid.Column="3" Style="{StaticResource IconButtonStyle}" ToolTip="Hledat" Command="{Binding SearchCommand}">
-                    <ui:Button.Icon>
-                        <ui:SymbolIcon Symbol="Search28" FontSize="{StaticResource IconSize}" />
-                    </ui:Button.Icon>
-                </ui:Button>
-            </Grid>
-
-            <!-- Filter panel -->
-            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="{StaticResource MarginBottomSpace16}">
-                <DatePicker SelectedDate="{Binding FromDate}" Width="150" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" ToolTip="Od"/>
-                <DatePicker SelectedDate="{Binding ToDate}" Width="150" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" ToolTip="Do"/>
-                <ui:TextBox Text="{Binding AuthorFilter, UpdateSourceTrigger=PropertyChanged}" Width="120" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" PlaceholderEnabled="True" PlaceholderText="Autor"/>
-                <ui:TextBox Text="{Binding VersionFilter, UpdateSourceTrigger=PropertyChanged}" Width="100" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" PlaceholderEnabled="True" PlaceholderText="Verze"/>
-                <ComboBox SelectedValuePath="Tag" SelectedValue="{Binding SortField}" Width="140" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}">
-                    <ComboBoxItem Content="Název" Tag="FileName"/>
-                    <ComboBoxItem Content="Změněno" Tag="ModifiedUtc"/>
-                    <ComboBoxItem Content="Autor" Tag="Author"/>
-                    <ComboBoxItem Content="Verze" Tag="Version"/>
-                </ComboBox>
-                <ui:ToggleSwitch IsChecked="{Binding SortAscending}" Margin="{StaticResource Space8}">
-                    <ui:ToggleSwitch.OnContent>
-                        <ui:SymbolIcon Symbol="ArrowSortUpLines20" FontSize="{StaticResource IconSize}"/>
-                    </ui:ToggleSwitch.OnContent>
-                    <ui:ToggleSwitch.OffContent>
-                        <ui:SymbolIcon Symbol="ArrowSortDownLines20" FontSize="{StaticResource IconSize}"/>
-                    </ui:ToggleSwitch.OffContent>
-                </ui:ToggleSwitch>
-            </StackPanel>
-
-            <!-- Results and detail -->
-            <Grid Grid.Row="2">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" x:Name="ResultsColumn"/>
-                    <ColumnDefinition Width="320" x:Name="DetailColumn"/>
-                </Grid.ColumnDefinitions>
-
-                <ui:DataGrid x:Name="ResultsGrid" Grid.Column="0" Margin="{StaticResource MarginRightSpace16}"
-                              ItemsSource="{Binding ResultsView.View}"
-                              SelectedItem="{Binding SelectedDocument}"
-                              AutoGenerateColumns="False"
-                              CanUserSortColumns="True"
-                              IsReadOnly="True"
-                              RowStyle="{StaticResource SearchRowStyle}"
-                              Loaded="ResultsGrid_Loaded"
-                              PreviewMouseRightButtonDown="ResultsGrid_PreviewMouseRightButtonDown">
-                    <ui:DataGrid.ContextMenu>
-                        <ContextMenu Opened="ResultsGrid_ContextMenu_Opened">
-                            <MenuItem Header="Otevřít protokol" Click="OpenProtocol_Click" />
-                            <MenuItem Header="Otevřít detail souboru" Click="OpenFileDetail_Click" />
-                        </ContextMenu>
-                    </ui:DataGrid.ContextMenu>
-                    <ui:DataGrid.Columns>
-                        <DataGridTextColumn Header="Název" Binding="{Binding FileName}" SortMemberPath="SortKey" Width="*"/>
-                        <DataGridTextColumn Header="Autor" Binding="{Binding Author}" Width="120"/>
-                        <DataGridTextColumn Header="Verze" Binding="{Binding Version}" Width="80"/>
-                        <DataGridTextColumn Header="Typ" Binding="{Binding Ext}" Width="80"/>
-                        <DataGridTextColumn Header="Velikost" Binding="{Binding SizeBytes, Converter={StaticResource FileSizeConverter}}" Width="100"/>
-                        <DataGridTextColumn Header="Změněno" Binding="{Binding ModifiedUtc, Converter={StaticResource UtcToLocalConverter}}" Width="140"/>
-                    </ui:DataGrid.Columns>
-                </ui:DataGrid>
-
-                <Grid Grid.Column="1">
+        <TabControl Grid.Row="1" x:Name="MainTabControl" Margin="{StaticResource Space24}">
+            <TabItem Header="Hledání">
+                <Grid>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="*"/>
                         <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <Border Grid.Row="0" BorderThickness="1" BorderBrush="{DynamicResource StrokeBrush}">
-                        <ContentControl x:Name="PreviewHost" />
-                    </Border>
-                    <ui:Button Grid.Row="1" Content="Otevřít" Command="{Binding OpenDocumentCommand}" Margin="{StaticResource MarginTopSpace16}"/>
+
+                    <!-- Search bar -->
+                    <Grid Grid.Row="0" Margin="{StaticResource MarginBottomSpace16}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <ui:Button x:Name="MenuButton" Grid.Column="0" Style="{StaticResource IconButtonStyle}" ToolTip="Menu" Click="MenuButton_Click">
+                            <ui:Button.Icon>
+                                <ui:SymbolIcon Symbol="Navigation16" FontSize="{StaticResource IconSize}" />
+                            </ui:Button.Icon>
+                            <ui:Button.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Header="Nové hledání" Click="Menu_NewSearch_Click">
+                                        <MenuItem.Icon>
+                                            <ui:SymbolIcon Symbol="Search28" />
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem Header="Správa protokolů" Click="Menu_Protocols_Click">
+                                        <MenuItem.Icon>
+                                            <ui:SymbolIcon Symbol="ClipboardTextLtr24" />
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem Header="Nastavení…" Click="Menu_Settings_Click">
+                                        <MenuItem.Icon>
+                                            <ui:SymbolIcon Symbol="Settings28" />
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem Header="Přeindexovat" Click="Menu_Reindex_Click">
+                                        <MenuItem.Icon>
+                                            <ui:SymbolIcon Symbol="ArrowClockwise28" />
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem x:Name="PauseResumeMenuItem" Header="Pozastavit indexaci" Click="Menu_PauseResume_Click">
+                                        <MenuItem.Icon>
+                                            <ui:SymbolIcon x:Name="PauseResumeIcon" Symbol="PauseCircle24" />
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                    <MenuItem Header="Ukončit" Click="Menu_Exit_Click">
+                                        <MenuItem.Icon>
+                                            <ui:SymbolIcon Symbol="Dismiss28" />
+                                        </MenuItem.Icon>
+                                    </MenuItem>
+                                </ContextMenu>
+                            </ui:Button.ContextMenu>
+                        </ui:Button>
+
+                        <ui:TextBox x:Name="QueryTextBox" Grid.Column="1" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}"
+                                    Text="{Binding Query, UpdateSourceTrigger=PropertyChanged}" Padding="{StaticResource Space12}"
+                                    PlaceholderEnabled="True" PlaceholderText="Hledat…"/>
+
+                        <ComboBox Grid.Column="2" SelectedValuePath="Tag" SelectedValue="{Binding FileTypeFilter}"
+                                  Width="100" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}">
+                            <ComboBoxItem Content="Vše" Tag="all" />
+                            <ComboBoxItem Content="PDF" Tag="pdf" />
+                            <ComboBoxItem Content="DOCX" Tag="docx" />
+                        </ComboBox>
+
+                        <ui:Button Grid.Column="3" Style="{StaticResource IconButtonStyle}" ToolTip="Hledat" Command="{Binding SearchCommand}">
+                            <ui:Button.Icon>
+                                <ui:SymbolIcon Symbol="Search28" FontSize="{StaticResource IconSize}" />
+                            </ui:Button.Icon>
+                        </ui:Button>
+                    </Grid>
+
+                    <!-- Filter panel -->
+                    <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="{StaticResource MarginBottomSpace16}">
+                        <DatePicker SelectedDate="{Binding FromDate}" Width="150" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" ToolTip="Od"/>
+                        <DatePicker SelectedDate="{Binding ToDate}" Width="150" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" ToolTip="Do"/>
+                        <ui:TextBox Text="{Binding AuthorFilter, UpdateSourceTrigger=PropertyChanged}" Width="120" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" PlaceholderEnabled="True" PlaceholderText="Autor"/>
+                        <ui:TextBox Text="{Binding VersionFilter, UpdateSourceTrigger=PropertyChanged}" Width="100" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}" PlaceholderEnabled="True" PlaceholderText="Verze"/>
+                        <ComboBox SelectedValuePath="Tag" SelectedValue="{Binding SortField}" Width="140" Height="{StaticResource ControlHeight}" Margin="{StaticResource Space8}">
+                            <ComboBoxItem Content="Název" Tag="FileName"/>
+                            <ComboBoxItem Content="Změněno" Tag="ModifiedUtc"/>
+                            <ComboBoxItem Content="Autor" Tag="Author"/>
+                            <ComboBoxItem Content="Verze" Tag="Version"/>
+                        </ComboBox>
+                        <ui:ToggleSwitch IsChecked="{Binding SortAscending}" Margin="{StaticResource Space8}">
+                            <ui:ToggleSwitch.OnContent>
+                                <ui:SymbolIcon Symbol="ArrowSortUpLines20" FontSize="{StaticResource IconSize}"/>
+                            </ui:ToggleSwitch.OnContent>
+                            <ui:ToggleSwitch.OffContent>
+                                <ui:SymbolIcon Symbol="ArrowSortDownLines20" FontSize="{StaticResource IconSize}"/>
+                            </ui:ToggleSwitch.OffContent>
+                        </ui:ToggleSwitch>
+                    </StackPanel>
+
+                    <!-- Results and detail -->
+                    <Grid Grid.Row="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" x:Name="ResultsColumn"/>
+                            <ColumnDefinition Width="320" x:Name="DetailColumn"/>
+                        </Grid.ColumnDefinitions>
+
+                        <ui:DataGrid x:Name="ResultsGrid" Grid.Column="0" Margin="{StaticResource MarginRightSpace16}"
+                                      ItemsSource="{Binding ResultsView.View}"
+                                      SelectedItem="{Binding SelectedDocument}"
+                                      AutoGenerateColumns="False"
+                                      CanUserSortColumns="True"
+                                      IsReadOnly="True"
+                                      RowStyle="{StaticResource SearchRowStyle}"
+                                      Loaded="ResultsGrid_Loaded"
+                                      PreviewMouseRightButtonDown="ResultsGrid_PreviewMouseRightButtonDown">
+                            <ui:DataGrid.ContextMenu>
+                                <ContextMenu Opened="ResultsGrid_ContextMenu_Opened">
+                                    <MenuItem Header="Otevřít protokol" Click="OpenProtocol_Click" />
+                                    <MenuItem Header="Otevřít detail souboru" Click="OpenFileDetail_Click" />
+                                </ContextMenu>
+                            </ui:DataGrid.ContextMenu>
+                            <ui:DataGrid.Columns>
+                                <DataGridTextColumn Header="Název" Binding="{Binding FileName}" SortMemberPath="SortKey" Width="*"/>
+                                <DataGridTextColumn Header="Autor" Binding="{Binding Author}" Width="120"/>
+                                <DataGridTextColumn Header="Verze" Binding="{Binding Version}" Width="80"/>
+                                <DataGridTextColumn Header="Typ" Binding="{Binding Ext}" Width="80"/>
+                                <DataGridTextColumn Header="Velikost" Binding="{Binding SizeBytes, Converter={StaticResource FileSizeConverter}}" Width="100"/>
+                                <DataGridTextColumn Header="Změněno" Binding="{Binding ModifiedUtc, Converter={StaticResource UtcToLocalConverter}}" Width="140"/>
+                            </ui:DataGrid.Columns>
+                        </ui:DataGrid>
+
+                        <Grid Grid.Column="1">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <Border Grid.Row="0" BorderThickness="1" BorderBrush="{DynamicResource StrokeBrush}">
+                                <ContentControl x:Name="PreviewHost" />
+                            </Border>
+                            <ui:Button Grid.Row="1" Content="Otevřít" Command="{Binding OpenDocumentCommand}" Margin="{StaticResource MarginTopSpace16}"/>
+                        </Grid>
+                    </Grid>
                 </Grid>
-            </Grid>
-        </Grid>
+            </TabItem>
+            <TabItem Header="Protokoly">
+                <controls:ProtocolListControl x:Name="ProtocolsTab" />
+            </TabItem>
+        </TabControl>
     </Grid>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
@@ -12,6 +12,7 @@ using Wpf.Ui.Controls;
 using DocFinder.App.ViewModels;
 using DocFinder.Indexing;
 using DocFinder.App.Services;
+using DocFinder.App.Views.Controls;
 
 namespace DocFinder.App.Views.Windows;
 
@@ -94,8 +95,8 @@ public partial class SearchOverlay : FluentWindow
 
     private void Menu_Protocols_Click(object sender, RoutedEventArgs e)
     {
-        var window = new ProtocolWindow();
-        window.Show();
+        MainTabControl.SelectedIndex = 1;
+        ProtocolsTab.FilterByPath(null);
     }
 
     private async void Menu_Reindex_Click(object sender, RoutedEventArgs e)
@@ -150,8 +151,8 @@ public partial class SearchOverlay : FluentWindow
     {
         if (_viewModel.SelectedDocument == null)
             return;
-        var window = new ProtocolWindow(_viewModel.SelectedDocument.Path);
-        window.Show();
+        MainTabControl.SelectedIndex = 1;
+        ProtocolsTab.FilterByPath(_viewModel.SelectedDocument.Path);
     }
 
     private void ResultsGrid_ContextMenu_Opened(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- Add ProtocolListControl to share protocol management UI
- Embed protocol list into SearchOverlay via new tab control
- Simplify ProtocolWindow to reuse ProtocolListControl

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bc002e45408326b253df0c59255135