### PR TITLE
Fix ambiguous WPF control references

### DIFF
--- a/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml.cs
+++ b/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml.cs
@@ -10,7 +10,6 @@ using DocFinder.Services;
 using DocFinder.Domain;
 using Microsoft.EntityFrameworkCore;
 using DocFinder.App.ViewModels.Entities;
-using Wpf.Ui.Controls;
 
 namespace DocFinder.App.Views.Controls;
 
@@ -87,7 +86,7 @@ public partial class ProtocolListControl : UserControl
             }
             else
             {
-                var messageBox = new MessageBox
+                var messageBox = new Wpf.Ui.Controls.MessageBox
                 {
                     Title = "DocFinder",
                     Content = "Soubor neexistuje.",

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -139,11 +138,11 @@ public partial class SearchOverlay : FluentWindow
     private void ResultsGrid_PreviewMouseRightButtonDown(object sender, MouseButtonEventArgs e)
     {
         var depObj = e.OriginalSource as DependencyObject;
-        while (depObj != null && depObj is not DataGridRow)
+        while (depObj != null && depObj is not System.Windows.Controls.DataGridRow)
             depObj = VisualTreeHelper.GetParent(depObj);
-        if (depObj is DataGridRow row)
+        if (depObj is System.Windows.Controls.DataGridRow row)
             row.IsSelected = true;
-        else if (sender is DataGrid grid)
+        else if (sender is System.Windows.Controls.DataGrid grid)
             grid.UnselectAll();
     }
 
@@ -157,10 +156,10 @@ public partial class SearchOverlay : FluentWindow
 
     private void ResultsGrid_ContextMenu_Opened(object sender, RoutedEventArgs e)
     {
-        if (sender is not ContextMenu menu)
+        if (sender is not System.Windows.Controls.ContextMenu menu)
             return;
 
-        var items = menu.Items.OfType<MenuItem>().ToList();
+        var items = menu.Items.OfType<System.Windows.Controls.MenuItem>().ToList();
         var openProtocol = items.FirstOrDefault(i => i.Header?.ToString() == "Otevřít protokol");
         var openDetail = items.FirstOrDefault(i => i.Header?.ToString() == "Otevřít detail souboru");
 


### PR DESCRIPTION
## Summary
- Resolve ambiguous WPF control types by removing conflicting namespaces
- Qualify DataGrid, MenuItem, and ContextMenu usages to pick the expected controls

## Testing
- `dotnet build` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*
- `dotnet test` *(fails: Attempting to cancel the build...)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0513d0b08326a2cf3a3b29f36f82