### PR TITLE
Fix ProtocolListControl namespace resolution

### DIFF
--- a/src/DocFinder.App/Views/Windows/ProtocolWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/ProtocolWindow.xaml
@@ -2,7 +2,7 @@
                  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                  xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-                 xmlns:controls="clr-namespace:DocFinder.App.Views.Controls"
+                 xmlns:controls="clr-namespace:DocFinder.App.Views.Controls;assembly=DocFinder.App"
                  Title="Protocols" Width="900" Height="450"
                  ExtendsContentIntoTitleBar="True"
                  WindowBackdropType="Mica"

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:converters="clr-namespace:DocFinder.App.Converters"
-    xmlns:controls="clr-namespace:DocFinder.App.Views.Controls"
+    xmlns:controls="clr-namespace:DocFinder.App.Views.Controls;assembly=DocFinder.App"
     Title="DocFinder" Width="900" Height="520"
     FontSize="{DynamicResource BodyFontSize}"
     WindowStartupLocation="CenterScreen"


### PR DESCRIPTION
## Summary
- ensure ProtocolListControl resolves by specifying assembly in XAML namespace declarations

## Testing
- `dotnet build` *(fails: imported project Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0d10f52c8326bc1772746f2b010e