### PR TITLE
Fix ProtocolListControl initialization and context menu

### DIFF
--- a/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml
+++ b/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml
@@ -35,9 +35,9 @@
                     <DataGridTextColumn Header="Date" Binding="{Binding IssueDateUtc}" />
                 </ui:DataGrid.Columns>
                 <ui:DataGrid.ContextMenu>
-                    <ui:ContextMenu>
-                        <ui:MenuItem Header="Open File" Click="OpenFile_Click" />
-                    </ui:ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="Open File" Click="OpenFile_Click" />
+                    </ContextMenu>
                 </ui:DataGrid.ContextMenu>
             </ui:DataGrid>
         </ui:Card>

--- a/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml.cs
+++ b/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml.cs
@@ -24,6 +24,7 @@ public partial class ProtocolListControl : UserControl
     {
         InitializeComponent();
         _context = new DocumentDbContext();
+        _context.Database.Migrate();
         protocolsGrid.ItemsSource = _protocols;
         _view = CollectionViewSource.GetDefaultView(_protocols);
         _view.Filter = Filter;


### PR DESCRIPTION
## Summary
- fix ProtocolListControl's context menu by using default WPF ContextMenu/MenuItem
- ensure DocumentDbContext migrations run before querying ProtocolListControl

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj --no-build --no-restore` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bd70dc81288326b4d6af282642af88