### PR TITLE
Ensure protocol table creation and ignore local database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+# SQLite database
+documents.db
+

--- a/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml.cs
+++ b/src/DocFinder.App/Views/Controls/ProtocolListControl.xaml.cs
@@ -24,7 +24,7 @@ public partial class ProtocolListControl : UserControl
     {
         InitializeComponent();
         _context = new DocumentDbContext();
-        _context.Database.Migrate();
+        _context.Database.EnsureCreated();
         protocolsGrid.ItemsSource = _protocols;
         _view = CollectionViewSource.GetDefaultView(_protocols);
         _view.Filter = Filter;


### PR DESCRIPTION
## Summary
- Replace EF migration call with EnsureCreated to avoid missing Protocols table during control initialization
- Ignore local documents.db file to allow EF to create schema dynamically

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj` *(fails: test run hangs after skipping tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd76bfbbfc832687bb7735904522b2