### PR TITLE
Ensure SearchOverlay closes the app

### DIFF
--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
@@ -45,6 +45,16 @@ public partial class SearchOverlay : FluentWindow
         ApplyResponsiveLayout(ActualWidth);
     }
 
+    /// <summary>
+    /// Ensures that closing this window also shuts down the application.
+    /// </summary>
+    /// <param name="e">Event data for the window closed event.</param>
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+        System.Windows.Application.Current.Shutdown();
+    }
+
     private void OnThemeChanged(ApplicationTheme newTheme, Color accentColor)
         => ApplyTheme(newTheme);
 


### PR DESCRIPTION
## Summary
- exit application when the SearchOverlay window is closed

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd93255a5083269c4ec1b29496d934