### PR TITLE
Add startup loading screen

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -67,12 +67,17 @@ public partial class App
 
     private async void OnStartup(object sender, StartupEventArgs e)
     {
+        var loadingWindow = new LoadingWindow();
+        loadingWindow.Show();
+
         // Load user settings before any services are started so that other
         // services (like the file watcher) receive the correct configuration.
         var settings = Services.GetRequiredService<ISettingsService>();
         await settings.LoadAsync();
 
         await _host.StartAsync();
+
+        loadingWindow.Close();
 
         var overlay = Services.GetRequiredService<SearchOverlay>();
         overlay.Show();

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -1,0 +1,19 @@
+<ui:FluentWindow
+    x:Class="DocFinder.App.Views.Windows.LoadingWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="DocFinder"
+    Width="300"
+    Height="200"
+    WindowStartupLocation="CenterScreen"
+    WindowStyle="None"
+    ResizeMode="NoResize"
+    ShowInTaskbar="False">
+    <Grid>
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+            <TextBlock Text="Načítání…" FontSize="16" Margin="0,0,0,12" HorizontalAlignment="Center"/>
+            <ProgressBar IsIndeterminate="True" Width="200" Height="20"/>
+        </StackPanel>
+    </Grid>
+</ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
@@ -1,0 +1,12 @@
+using Wpf.Ui.Controls;
+
+namespace DocFinder.App.Views.Windows;
+
+public partial class LoadingWindow : FluentWindow
+{
+    public LoadingWindow()
+    {
+        InitializeComponent();
+    }
+}
+


### PR DESCRIPTION
## Summary
- show a loading window before services start
- close loading window then launch search overlay

## Testing
- `dotnet test -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd991223dc83269e081f44e1da17f6