### PR TITLE
Apply theme settings to loading screen

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -17,6 +17,7 @@ using DocFinder.Indexing;
 using DocFinder.Application;
 using DocFinder.Application.Commands;
 using DocFinder.Application.Handlers;
+using Wpf.Ui.Appearance;
 
 namespace DocFinder.App;
 
@@ -67,13 +68,20 @@ public partial class App
 
     private async void OnStartup(object sender, StartupEventArgs e)
     {
-        var loadingWindow = new LoadingWindow();
-        loadingWindow.Show();
-
         // Load user settings before any services are started so that other
         // services (like the file watcher) receive the correct configuration.
         var settings = Services.GetRequiredService<ISettingsService>();
         await settings.LoadAsync();
+
+        // Apply the configured theme so that the loading window uses it immediately
+        var themeName = settings.Current.Theme;
+        var theme = themeName.Equals("Dark", StringComparison.OrdinalIgnoreCase)
+            ? ApplicationTheme.Dark
+            : ApplicationTheme.Light;
+        ApplicationThemeManager.Apply(theme);
+
+        var loadingWindow = new LoadingWindow();
+        loadingWindow.Show();
 
         await _host.StartAsync();
 

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -10,10 +10,12 @@
     WindowStyle="None"
     ResizeMode="NoResize"
     ShowInTaskbar="False">
-    <Grid>
+    <Grid Background="{DynamicResource SurfaceBackgroundBrush}">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-            <TextBlock Text="Načítání…" FontSize="16" Margin="0,0,0,12" HorizontalAlignment="Center"/>
-            <ProgressBar IsIndeterminate="True" Width="200" Height="20"/>
+            <TextBlock Text="Načítání…" FontSize="16" Margin="0,0,0,12" HorizontalAlignment="Center"
+                       Foreground="{DynamicResource TextPrimaryBrush}"/>
+            <ProgressBar IsIndeterminate="True" Width="200" Height="20"
+                         Foreground="{DynamicResource AccentBrush}"/>
         </StackPanel>
     </Grid>
 </ui:FluentWindow>


### PR DESCRIPTION
## Summary
- Load user settings early and apply saved theme before showing loading window
- Use theme resource brushes for loading screen background, text, and progress bar

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9d750a9c83268911bdbcfd0a4e84