### PR TITLE
Use WPF UI TabControl for search overlay

### DIFF
--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -71,8 +71,8 @@
 
         <ui:TitleBar Grid.Row="0" Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}" />
 
-        <TabControl Grid.Row="1" x:Name="MainTabControl" Margin="{StaticResource Space24}">
-            <TabItem Header="Hledání">
+        <ui:TabControl Grid.Row="1" x:Name="MainTabControl" Margin="{StaticResource Space24}">
+            <ui:TabItem Header="Hledání">
                 <Grid>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -207,7 +207,7 @@
                         </Grid>
                     </Grid>
                 </Grid>
-            </TabItem>
-        </TabControl>
+            </ui:TabItem>
+        </ui:TabControl>
     </Grid>
 </ui:FluentWindow>


### PR DESCRIPTION
## Summary
- switch SearchOverlay window to use WPF UI `TabControl` and `TabItem`

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj --filter "FileTests"`


------
https://chatgpt.com/codex/tasks/task_e_68bda8fed400832693f702a5047bbd12