### PR TITLE
Replace TabControl with WPF UI Page

### DIFF
--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -71,14 +71,13 @@
 
         <ui:TitleBar Grid.Row="0" Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}" />
 
-        <ui:TabControl Grid.Row="1" x:Name="MainTabControl" Margin="{StaticResource Space24}">
-            <ui:TabItem Header="Hledání">
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="*"/>
-                    </Grid.RowDefinitions>
+        <ui:Page Grid.Row="1" x:Name="SearchPage" Margin="{StaticResource Space24}" Title="Hledání">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
 
                     <!-- Search bar -->
                     <Grid Grid.Row="0" Margin="{StaticResource MarginBottomSpace16}">
@@ -165,11 +164,11 @@
                     </StackPanel>
 
                     <!-- Results and detail -->
-                    <Grid Grid.Row="2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" x:Name="ResultsColumn"/>
-                            <ColumnDefinition Width="320" x:Name="DetailColumn"/>
-                        </Grid.ColumnDefinitions>
+                <Grid Grid.Row="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" x:Name="ResultsColumn"/>
+                        <ColumnDefinition Width="320" x:Name="DetailColumn"/>
+                    </Grid.ColumnDefinitions>
 
                         <ui:DataGrid x:Name="ResultsGrid" Grid.Column="0" Margin="{StaticResource MarginRightSpace16}"
                                       ItemsSource="{Binding ResultsView.View}"
@@ -205,9 +204,8 @@
                             </Border>
                             <ui:Button Grid.Row="1" Content="Otevřít" Command="{Binding OpenDocumentCommand}" Margin="{StaticResource MarginTopSpace16}"/>
                         </Grid>
-                    </Grid>
                 </Grid>
-            </ui:TabItem>
-        </ui:TabControl>
+            </Grid>
+        </ui:Page>
     </Grid>
 </ui:FluentWindow>


### PR DESCRIPTION
## Summary
- use `ui:Page` in SearchOverlay to align with WPF UI navigation

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test` *(skipped tests; build cancellation)*

------
https://chatgpt.com/codex/tasks/task_e_68bdaf26af988326b4da2ed2331a6e3a