### PR TITLE
Use MainWindow as base window

### DIFF
--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -1,8 +1,9 @@
-<ui:FluentWindow
+<local:MainWindow
     x:Class="DocFinder.App.Views.Windows.LoadingWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:local="clr-namespace:DocFinder.App.Views.Windows"
     Title="DocFinder"
     Width="300"
     Height="200"
@@ -18,4 +19,4 @@
                          Foreground="{DynamicResource AccentBrush}"/>
         </StackPanel>
     </Grid>
-</ui:FluentWindow>
+</local:MainWindow>

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
@@ -2,7 +2,7 @@ using Wpf.Ui.Controls;
 
 namespace DocFinder.App.Views.Windows;
 
-public partial class LoadingWindow : FluentWindow
+public partial class LoadingWindow : MainWindow
 {
     public LoadingWindow()
     {

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
@@ -6,20 +6,23 @@ using Wpf.Ui.Controls;
 
 namespace DocFinder.App.Views.Windows
 {
-    public partial class MainWindow : INavigationWindow
+    public partial class MainWindow : FluentWindow, INavigationWindow
     {
-        public MainWindowViewModel ViewModel { get; }
+        public MainWindowViewModel? ViewModel { get; }
+
+        public MainWindow()
+        {
+            SystemThemeWatcher.Watch(this);
+        }
 
         public MainWindow(
             MainWindowViewModel viewModel,
             INavigationViewPageProvider navigationViewPageProvider,
             INavigationService navigationService
-        )
+        ) : this()
         {
             ViewModel = viewModel;
             DataContext = this;
-
-            SystemThemeWatcher.Watch(this);
 
             InitializeComponent();
             SetPageService(navigationViewPageProvider);
@@ -50,11 +53,6 @@ namespace DocFinder.App.Views.Windows
 
             // Make sure that closing this window will begin the process of closing the application.
             System.Windows.Application.Current.Shutdown();
-        }
-
-        INavigationView INavigationWindow.GetNavigation()
-        {
-            throw new NotImplementedException();
         }
 
         public void SetServiceProvider(IServiceProvider serviceProvider)

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -1,8 +1,9 @@
-<ui:FluentWindow x:Class="DocFinder.App.Views.Windows.SearchOverlay"
+<local:MainWindow x:Class="DocFinder.App.Views.Windows.SearchOverlay"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:converters="clr-namespace:DocFinder.App.Converters"
+    xmlns:local="clr-namespace:DocFinder.App.Views.Windows"
     Title="DocFinder" Width="900" Height="520"
     FontSize="{DynamicResource BodyFontSize}"
     WindowStartupLocation="CenterScreen"
@@ -12,7 +13,7 @@
     WindowBackdropType="Mica"
     ResizeMode="CanResize"
     ShowInTaskbar="True">
-    <ui:FluentWindow.Resources>
+    <local:MainWindow.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/DocFinder.App;component/Resources/DesignTokens.xaml" />
@@ -62,7 +63,7 @@
                 </Style.Triggers>
             </Style>
         </ResourceDictionary>
-    </ui:FluentWindow.Resources>
+    </local:MainWindow.Resources>
     <Grid Background="{DynamicResource SurfaceBackgroundBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -206,4 +207,4 @@
             </Grid>
         </Grid>
     </Grid>
-</ui:FluentWindow>
+</local:MainWindow>

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
@@ -14,7 +14,7 @@ using DocFinder.App.Services;
 
 namespace DocFinder.App.Views.Windows;
 
-public partial class SearchOverlay : FluentWindow
+public partial class SearchOverlay : MainWindow
 {
     private readonly SearchOverlayViewModel _viewModel;
     private readonly IIndexer _indexer;

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
@@ -1,7 +1,8 @@
-<ui:FluentWindow x:Class="DocFinder.App.Views.Windows.SettingsWindow"
+<local:MainWindow x:Class="DocFinder.App.Views.Windows.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:local="clr-namespace:DocFinder.App.Views.Windows"
     Title="Settings" Width="500" Height="400"
     WindowStartupLocation="CenterOwner"
     ExtendsContentIntoTitleBar="True"
@@ -45,4 +46,4 @@
             </DataGrid>
         </StackPanel>
     </Grid>
-</ui:FluentWindow>
+</local:MainWindow>

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml.cs
@@ -3,7 +3,7 @@ using DocFinder.App.ViewModels;
 
 namespace DocFinder.App.Views.Windows;
 
-public partial class SettingsWindow : FluentWindow
+public partial class SettingsWindow : MainWindow
 {
     public SettingsViewModel ViewModel { get; }
 


### PR DESCRIPTION
## Summary
- Ensure `MainWindow` explicitly derives from `FluentWindow` and expose a base constructor
- Make `SettingsWindow`, `LoadingWindow`, and `SearchOverlay` derive from `MainWindow` in both code and XAML

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8bf0e7083268e223e511906cb27