### PR TITLE
Fix NavigationView content usage in window XAML

### DIFF
--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -27,12 +27,14 @@
 
         <!-- Body & Navigation -->
         <ui:NavigationView Grid.Row="1" PaneDisplayMode="LeftFluent">
+            <ui:NavigationView.Content>
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="Načítání…" FontSize="16" Margin="0,0,0,12" HorizontalAlignment="Center"
                            Foreground="{DynamicResource TextPrimaryBrush}"/>
                 <ProgressBar IsIndeterminate="True" Width="200" Height="20"
                              Foreground="{DynamicResource AccentBrush}"/>
             </StackPanel>
+            </ui:NavigationView.Content>
         </ui:NavigationView>
 
         <!-- Footer -->

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -80,6 +80,7 @@
 
         <!-- Body & Navigation -->
         <ui:NavigationView Grid.Row="1" PaneDisplayMode="LeftFluent">
+            <ui:NavigationView.Content>
             <Grid x:Name="SearchPage" Margin="{StaticResource Space24}">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -214,6 +215,7 @@
                 </Grid>
             </Grid>
             </Grid>
+            </ui:NavigationView.Content>
         </ui:NavigationView>
 
         <!-- Footer -->

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
@@ -24,6 +24,7 @@
 
         <!-- Body & Navigation -->
         <ui:NavigationView Grid.Row="1" PaneDisplayMode="LeftFluent">
+            <ui:NavigationView.Content>
             <StackPanel Margin="20">
                 <TextBlock Text="Source Folder"/>
                 <TextBox Text="{Binding Settings.SourceRoot, UpdateSourceTrigger=PropertyChanged}"/>
@@ -53,6 +54,7 @@
                     </DataGrid.Columns>
                 </DataGrid>
             </StackPanel>
+            </ui:NavigationView.Content>
         </ui:NavigationView>
 
         <!-- Footer -->


### PR DESCRIPTION
## Summary
- wrap NavigationView child content with NavigationView.Content in SearchOverlay
- apply same fix in SettingsWindow and LoadingWindow to prevent direct content errors

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test` *(2 tests skipped; command hung and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68be7aac8bf88326af1d19b879a55125