### PR TITLE
Fix NavigationView content usage in auxiliary windows

### DIFF
--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -25,17 +25,13 @@
             </ui:TitleBar.Icon>
         </ui:TitleBar>
 
-        <!-- Body & Navigation -->
-        <ui:NavigationView Grid.Row="1" PaneDisplayMode="LeftFluent">
-            <ui:NavigationView.Content>
-            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+        <!-- Body -->
+        <StackPanel Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="Načítání…" FontSize="16" Margin="0,0,0,12" HorizontalAlignment="Center"
                            Foreground="{DynamicResource TextPrimaryBrush}"/>
                 <ProgressBar IsIndeterminate="True" Width="200" Height="20"
                              Foreground="{DynamicResource AccentBrush}"/>
-            </StackPanel>
-            </ui:NavigationView.Content>
-        </ui:NavigationView>
+        </StackPanel>
 
         <!-- Footer -->
         <Border Grid.Row="2" Background="{DynamicResource ApplicationBackgroundBrush}">

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -78,15 +78,13 @@
             </ui:TitleBar.Icon>
         </ui:TitleBar>
 
-        <!-- Body & Navigation -->
-        <ui:NavigationView Grid.Row="1" PaneDisplayMode="LeftFluent">
-            <ui:NavigationView.Content>
-            <Grid x:Name="SearchPage" Margin="{StaticResource Space24}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
+        <!-- Body -->
+        <Grid Grid.Row="1" Margin="{StaticResource Space24}" x:Name="SearchPage">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
             <!-- Search bar -->
             <Grid Grid.Row="0" Margin="{StaticResource MarginBottomSpace16}">
@@ -215,8 +213,7 @@
                 </Grid>
             </Grid>
             </Grid>
-            </ui:NavigationView.Content>
-        </ui:NavigationView>
+        </Grid>
 
         <!-- Footer -->
         <Border Grid.Row="2" Background="{DynamicResource ApplicationBackgroundBrush}">

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
@@ -22,10 +22,8 @@
             </ui:TitleBar.Icon>
         </ui:TitleBar>
 
-        <!-- Body & Navigation -->
-        <ui:NavigationView Grid.Row="1" PaneDisplayMode="LeftFluent">
-            <ui:NavigationView.Content>
-            <StackPanel Margin="20">
+        <!-- Body -->
+        <StackPanel Grid.Row="1" Margin="20">
                 <TextBlock Text="Source Folder"/>
                 <TextBox Text="{Binding Settings.SourceRoot, UpdateSourceTrigger=PropertyChanged}"/>
                 <TextBlock Margin="0,12,0,0" Text="Watched Folders (one per line)"/>
@@ -53,9 +51,7 @@
                         <DataGridTextColumn Header="Soubor" Binding="{Binding}" />
                     </DataGrid.Columns>
                 </DataGrid>
-            </StackPanel>
-            </ui:NavigationView.Content>
-        </ui:NavigationView>
+        </StackPanel>
 
         <!-- Footer -->
         <Border Grid.Row="2" Background="{DynamicResource ApplicationBackgroundBrush}">


### PR DESCRIPTION
## Summary
- remove unsupported `NavigationView.Content` blocks
- simplify body layout for loading, settings and search overlay windows

## Testing
- `dotnet build DocFinder.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj --no-build --verbosity minimal` *(hung after running; tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68be7e81438c8326a9bbfc761574fe09