### PR TITLE
Refactor ancillary windows to use FluentWindow base

### DIFF
--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -1,9 +1,8 @@
-<local:MainWindow
+<ui:FluentWindow
     x:Class="DocFinder.App.Views.Windows.LoadingWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Windows"
     Title="DocFinder"
     Width="300"
     Height="200"
@@ -38,4 +37,4 @@
             <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
         </Border>
     </Grid>
-</local:MainWindow>
+</ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
@@ -2,7 +2,7 @@ using Wpf.Ui.Controls;
 
 namespace DocFinder.App.Views.Windows;
 
-public partial class LoadingWindow : MainWindow
+public partial class LoadingWindow : FluentWindow
 {
     public LoadingWindow()
     {

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -1,9 +1,8 @@
-<local:MainWindow x:Class="DocFinder.App.Views.Windows.SearchOverlay"
+<ui:FluentWindow x:Class="DocFinder.App.Views.Windows.SearchOverlay"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:converters="clr-namespace:DocFinder.App.Converters"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Windows"
     Title="DocFinder" Width="900" Height="520"
     FontSize="{DynamicResource BodyFontSize}"
     WindowStartupLocation="CenterScreen"
@@ -13,7 +12,7 @@
     WindowBackdropType="Mica"
     ResizeMode="CanResize"
     ShowInTaskbar="True">
-    <local:MainWindow.Resources>
+    <ui:FluentWindow.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="/DocFinder.App;component/Resources/DesignTokens.xaml" />
@@ -63,7 +62,7 @@
                 </Style.Triggers>
             </Style>
         </ResourceDictionary>
-    </local:MainWindow.Resources>
+    </ui:FluentWindow.Resources>
     <Grid Background="{DynamicResource SurfaceBackgroundBrush}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -220,4 +219,4 @@
             <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
         </Border>
     </Grid>
-</local:MainWindow>
+</ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
@@ -14,7 +14,7 @@ using DocFinder.App.Services;
 
 namespace DocFinder.App.Views.Windows;
 
-public partial class SearchOverlay : MainWindow
+public partial class SearchOverlay : FluentWindow
 {
     private readonly SearchOverlayViewModel _viewModel;
     private readonly IIndexer _indexer;

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
@@ -1,8 +1,7 @@
-<local:MainWindow x:Class="DocFinder.App.Views.Windows.SettingsWindow"
+<ui:FluentWindow x:Class="DocFinder.App.Views.Windows.SettingsWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Windows"
     Title="Settings" Width="500" Height="400"
     WindowStartupLocation="CenterOwner"
     ExtendsContentIntoTitleBar="True"
@@ -58,4 +57,4 @@
             <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
         </Border>
     </Grid>
-</local:MainWindow>
+</ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml.cs
@@ -3,7 +3,7 @@ using DocFinder.App.ViewModels;
 
 namespace DocFinder.App.Views.Windows;
 
-public partial class SettingsWindow : MainWindow
+public partial class SettingsWindow : FluentWindow
 {
     public SettingsViewModel ViewModel { get; }
 


### PR DESCRIPTION
## Summary
- Use `<ui:FluentWindow>` for LoadingWindow, SettingsWindow, and SearchOverlay XAML
- Update corresponding code-behind classes to inherit from `FluentWindow`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be8144793c83269952de5e94fd0503