### PR TITLE
refactor: unify window layout

### DIFF
--- a/src/DocFinder.App/Views/Layout/HeaderBodyFooterLayout.xaml
+++ b/src/DocFinder.App/Views/Layout/HeaderBodyFooterLayout.xaml
@@ -1,0 +1,14 @@
+<UserControl x:Class="DocFinder.App.Views.Layout.HeaderBodyFooterLayout"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid Background="{Binding Background, RelativeSource={RelativeSource AncestorType=UserControl}}">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <ContentPresenter Grid.Row="0" Content="{Binding Header, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+        <ContentPresenter Grid.Row="1" Content="{Binding Body, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+        <ContentPresenter Grid.Row="2" Content="{Binding Footer, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+    </Grid>
+</UserControl>

--- a/src/DocFinder.App/Views/Layout/HeaderBodyFooterLayout.xaml.cs
+++ b/src/DocFinder.App/Views/Layout/HeaderBodyFooterLayout.xaml.cs
@@ -1,0 +1,43 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace DocFinder.App.Views.Layout
+{
+    public partial class HeaderBodyFooterLayout : UserControl
+    {
+        public HeaderBodyFooterLayout()
+        {
+            InitializeComponent();
+        }
+
+        public static readonly DependencyProperty HeaderProperty =
+            DependencyProperty.Register(
+                nameof(Header), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
+
+        public static readonly DependencyProperty BodyProperty =
+            DependencyProperty.Register(
+                nameof(Body), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
+
+        public static readonly DependencyProperty FooterProperty =
+            DependencyProperty.Register(
+                nameof(Footer), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
+
+        public object? Header
+        {
+            get => GetValue(HeaderProperty);
+            set => SetValue(HeaderProperty, value);
+        }
+
+        public object? Body
+        {
+            get => GetValue(BodyProperty);
+            set => SetValue(BodyProperty, value);
+        }
+
+        public object? Footer
+        {
+            get => GetValue(FooterProperty);
+            set => SetValue(FooterProperty, value);
+        }
+    }
+}

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="DocFinder"
     Width="300"
     Height="200"
@@ -10,31 +11,28 @@
     WindowStyle="None"
     ResizeMode="NoResize"
     ShowInTaskbar="False">
-    <Grid Background="{DynamicResource SurfaceBackgroundBrush}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+    <layout:HeaderBodyFooterLayout Background="{DynamicResource SurfaceBackgroundBrush}">
+        <layout:HeaderBodyFooterLayout.Header>
+            <ui:TitleBar Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}">
+                <ui:TitleBar.Icon>
+                    <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
+                </ui:TitleBar.Icon>
+            </ui:TitleBar>
+        </layout:HeaderBodyFooterLayout.Header>
 
-        <!-- Header -->
-        <ui:TitleBar Grid.Row="0" Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}">
-            <ui:TitleBar.Icon>
-                <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
-            </ui:TitleBar.Icon>
-        </ui:TitleBar>
-
-        <!-- Body -->
-        <StackPanel Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <layout:HeaderBodyFooterLayout.Body>
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="Načítání…" FontSize="16" Margin="0,0,0,12" HorizontalAlignment="Center"
                            Foreground="{DynamicResource TextPrimaryBrush}"/>
                 <ProgressBar IsIndeterminate="True" Width="200" Height="20"
                              Foreground="{DynamicResource AccentBrush}"/>
-        </StackPanel>
+            </StackPanel>
+        </layout:HeaderBodyFooterLayout.Body>
 
-        <!-- Footer -->
-        <Border Grid.Row="2" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
-        </Border>
-    </Grid>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <Border Background="{DynamicResource ApplicationBackgroundBrush}">
+                <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
+            </Border>
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml
@@ -7,6 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Windows"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="{Binding ViewModel.ApplicationTitle, Mode=OneWay}"
     Width="1100"
     Height="650"
@@ -22,58 +23,50 @@
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+        <layout:HeaderBodyFooterLayout>
+            <layout:HeaderBodyFooterLayout.Header>
+                <ui:TitleBar
+                    x:Name="TitleBar"
+                    Title="{Binding ViewModel.ApplicationTitle}"
+                    CloseWindowByDoubleClickOnIcon="True">
+                    <ui:TitleBar.Icon>
+                        <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
+                    </ui:TitleBar.Icon>
+                </ui:TitleBar>
+            </layout:HeaderBodyFooterLayout.Header>
 
-        <!-- Header -->
-        <ui:TitleBar
-            x:Name="TitleBar"
-            Title="{Binding ViewModel.ApplicationTitle}"
-            Grid.Row="0"
-            CloseWindowByDoubleClickOnIcon="True">
-            <ui:TitleBar.Icon>
-                <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
-            </ui:TitleBar.Icon>
-        </ui:TitleBar>
+            <layout:HeaderBodyFooterLayout.Body>
+                <ui:NavigationView
+                    x:Name="RootNavigation"
+                    Padding="42,0,42,0"
+                    BreadcrumbBar="{Binding ElementName=BreadcrumbBar}"
+                    FooterMenuItemsSource="{Binding ViewModel.FooterMenuItems, Mode=OneWay}"
+                    FrameMargin="0"
+                    IsBackButtonVisible="Visible"
+                    IsPaneToggleVisible="True"
+                    MenuItemsSource="{Binding ViewModel.MenuItems, Mode=OneWay}"
+                    PaneDisplayMode="LeftFluent">
+                    <ui:NavigationView.Header>
+                        <ui:BreadcrumbBar x:Name="BreadcrumbBar" Margin="42,32,42,20" />
+                    </ui:NavigationView.Header>
+                    <ui:NavigationView.ContentOverlay>
+                        <Grid>
+                            <ui:SnackbarPresenter x:Name="SnackbarPresenter" />
+                        </Grid>
+                    </ui:NavigationView.ContentOverlay>
+                </ui:NavigationView>
+            </layout:HeaderBodyFooterLayout.Body>
 
-        <!-- Body & Navigation -->
-        <ui:NavigationView
-            x:Name="RootNavigation"
-            Grid.Row="1"
-            Padding="42,0,42,0"
-            BreadcrumbBar="{Binding ElementName=BreadcrumbBar}"
-            FooterMenuItemsSource="{Binding ViewModel.FooterMenuItems, Mode=OneWay}"
-            FrameMargin="0"
-            IsBackButtonVisible="Visible"
-            IsPaneToggleVisible="True"
-            MenuItemsSource="{Binding ViewModel.MenuItems, Mode=OneWay}"
-            PaneDisplayMode="LeftFluent">
-            <ui:NavigationView.Header>
-                <ui:BreadcrumbBar x:Name="BreadcrumbBar" Margin="42,32,42,20" />
-            </ui:NavigationView.Header>
-            <ui:NavigationView.ContentOverlay>
-                <Grid>
-                    <ui:SnackbarPresenter x:Name="SnackbarPresenter" />
-                </Grid>
-            </ui:NavigationView.ContentOverlay>
-        </ui:NavigationView>
+            <layout:HeaderBodyFooterLayout.Footer>
+                <Border Background="{DynamicResource ApplicationBackgroundBrush}">
+                    <ui:TextBlock
+                        Margin="12,8"
+                        HorizontalAlignment="Center"
+                        Text="© 2024 DocFinder" />
+                </Border>
+            </layout:HeaderBodyFooterLayout.Footer>
+        </layout:HeaderBodyFooterLayout>
 
-        <!-- Footer -->
-        <Border
-            Grid.Row="2"
-            Background="{DynamicResource ApplicationBackgroundBrush}">
-            <ui:TextBlock
-                Margin="12,8"
-                HorizontalAlignment="Center"
-                Text="© 2024 DocFinder" />
-        </Border>
-
-        <ContentPresenter
-            x:Name="RootContentDialog"
-            Grid.Row="0"
-            Grid.RowSpan="3" />
+        <ContentPresenter x:Name="RootContentDialog" />
     </Grid>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -3,6 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:converters="clr-namespace:DocFinder.App.Converters"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="DocFinder" Width="900" Height="520"
     FontSize="{DynamicResource BodyFontSize}"
     WindowStartupLocation="CenterScreen"
@@ -63,22 +64,17 @@
             </Style>
         </ResourceDictionary>
     </ui:FluentWindow.Resources>
-    <Grid Background="{DynamicResource SurfaceBackgroundBrush}">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+    <layout:HeaderBodyFooterLayout Background="{DynamicResource SurfaceBackgroundBrush}">
+        <layout:HeaderBodyFooterLayout.Header>
+            <ui:TitleBar Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}">
+                <ui:TitleBar.Icon>
+                    <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
+                </ui:TitleBar.Icon>
+            </ui:TitleBar>
+        </layout:HeaderBodyFooterLayout.Header>
 
-        <!-- Header -->
-        <ui:TitleBar Grid.Row="0" Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}">
-            <ui:TitleBar.Icon>
-                <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
-            </ui:TitleBar.Icon>
-        </ui:TitleBar>
-
-        <!-- Body -->
-        <Grid Grid.Row="1" Margin="{StaticResource Space24}" x:Name="SearchPage">
+        <layout:HeaderBodyFooterLayout.Body>
+            <Grid Margin="{StaticResource Space24}" x:Name="SearchPage">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -212,11 +208,13 @@
                 </Grid>
             </Grid>
             </Grid>
-        </Grid>
+            </Grid>
+        </layout:HeaderBodyFooterLayout.Body>
 
-        <!-- Footer -->
-        <Border Grid.Row="2" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
-        </Border>
-    </Grid>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <Border Background="{DynamicResource ApplicationBackgroundBrush}">
+                <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
+            </Border>
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
@@ -2,27 +2,23 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="Settings" Width="500" Height="400"
     WindowStartupLocation="CenterOwner"
     ExtendsContentIntoTitleBar="True"
     WindowBackdropType="Mica"
     ResizeMode="CanResize">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <ui:TitleBar Title="Settings" Foreground="{DynamicResource TextFillColorPrimaryBrush}">
+                <ui:TitleBar.Icon>
+                    <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
+                </ui:TitleBar.Icon>
+            </ui:TitleBar>
+        </layout:HeaderBodyFooterLayout.Header>
 
-        <!-- Header -->
-        <ui:TitleBar Grid.Row="0" Title="Settings" Foreground="{DynamicResource TextFillColorPrimaryBrush}">
-            <ui:TitleBar.Icon>
-                <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
-            </ui:TitleBar.Icon>
-        </ui:TitleBar>
-
-        <!-- Body -->
-        <StackPanel Grid.Row="1" Margin="20">
+        <layout:HeaderBodyFooterLayout.Body>
+            <StackPanel Margin="20">
                 <TextBlock Text="Source Folder"/>
                 <TextBox Text="{Binding Settings.SourceRoot, UpdateSourceTrigger=PropertyChanged}"/>
                 <TextBlock Margin="0,12,0,0" Text="Watched Folders (one per line)"/>
@@ -50,11 +46,13 @@
                         <DataGridTextColumn Header="Soubor" Binding="{Binding}" />
                     </DataGrid.Columns>
                 </DataGrid>
-        </StackPanel>
+            </StackPanel>
+        </layout:HeaderBodyFooterLayout.Body>
 
-        <!-- Footer -->
-        <Border Grid.Row="2" Background="{DynamicResource ApplicationBackgroundBrush}">
-            <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
-        </Border>
-    </Grid>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <Border Background="{DynamicResource ApplicationBackgroundBrush}">
+                <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
+            </Border>
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
 </ui:FluentWindow>


### PR DESCRIPTION
## Summary
- centralize header, body and footer layout in a reusable control
- update all windows to use the new layout so pages live in the body slot

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be83c416408326acab9eaa3f58b50a