### PR TITLE
fix: add navigation interface reference

### DIFF
--- a/src/DocFinder.App/ViewModels/Pages/SearchViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Pages/SearchViewModel.cs
@@ -1,3 +1,5 @@
+using Wpf.Ui.Abstractions.Controls;
+
 namespace DocFinder.App.ViewModels.Pages;
 
 public partial class SearchViewModel : ObservableObject, INavigationAware


### PR DESCRIPTION
## Summary
- import `Wpf.Ui.Abstractions.Controls` in `SearchViewModel` to access `INavigationAware`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bea632b44c8326b3d4ccdf614d3162