### PR TITLE
Fix layout namespaces and remove duplicate XAML names

### DIFF
--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout;assembly=DocFinder.App"
     Title="DocFinder"
     Width="300"
     Height="200"

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Windows"
-    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout;assembly=DocFinder.App"
     Title="{Binding ViewModel.ApplicationTitle, Mode=OneWay}"
     Width="1100"
     Height="650"
@@ -26,7 +26,6 @@
         <layout:HeaderBodyFooterLayout>
             <layout:HeaderBodyFooterLayout.Header>
                 <ui:TitleBar
-                    x:Name="TitleBar"
                     Title="{Binding ViewModel.ApplicationTitle}"
                     CloseWindowByDoubleClickOnIcon="True">
                     <ui:TitleBar.Icon>

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -2,8 +2,8 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:converters="clr-namespace:DocFinder.App.Converters"
-    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
+    xmlns:converters="clr-namespace:DocFinder.App.Converters;assembly=DocFinder.App"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout;assembly=DocFinder.App"
     Title="DocFinder" Width="900" Height="520"
     FontSize="{DynamicResource BodyFontSize}"
     WindowStartupLocation="CenterScreen"
@@ -90,7 +90,7 @@
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
 
-                <ui:Button x:Name="MenuButton" Grid.Column="0" Style="{StaticResource IconButtonStyle}" ToolTip="Menu" Click="MenuButton_Click">
+                <ui:Button Grid.Column="0" Style="{StaticResource IconButtonStyle}" ToolTip="Menu" Click="MenuButton_Click">
                     <ui:Button.Icon>
                         <ui:SymbolIcon Symbol="Navigation16" FontSize="{StaticResource IconSize}" />
                     </ui:Button.Icon>

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml.cs
@@ -83,10 +83,10 @@ public partial class SearchOverlay : FluentWindow
 
     private void MenuButton_Click(object sender, RoutedEventArgs e)
     {
-        if (MenuButton.ContextMenu != null)
+        if (sender is Button button && button.ContextMenu != null)
         {
-            MenuButton.ContextMenu.PlacementTarget = MenuButton;
-            MenuButton.ContextMenu.IsOpen = true;
+            button.ContextMenu.PlacementTarget = button;
+            button.ContextMenu.IsOpen = true;
         }
     }
 

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
@@ -2,7 +2,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout;assembly=DocFinder.App"
     Title="Settings" Width="500" Height="400"
     WindowStartupLocation="CenterOwner"
     ExtendsContentIntoTitleBar="True"


### PR DESCRIPTION
## Summary
- reference layout and converter namespaces with explicit assembly names
- remove duplicate control names that conflicted with layout scope
- update menu button handler to avoid named element dependency

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bea7cb100c83269bc6267c81fecb60