### PR TITLE
Add modular layout with header, menu, body and footer

### DIFF
--- a/src/DocFinder.App/Views/Layout/BodyView.xaml
+++ b/src/DocFinder.App/Views/Layout/BodyView.xaml
@@ -1,0 +1,24 @@
+<UserControl x:Class="DocFinder.App.Views.Layout.BodyView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    <ui:NavigationView
+        x:Name="RootNavigation"
+        Padding="42,0,42,0"
+        BreadcrumbBar="{Binding ElementName=BreadcrumbBar}"
+        FooterMenuItemsSource="{Binding ViewModel.FooterMenuItems, Mode=OneWay}"
+        FrameMargin="0"
+        IsBackButtonVisible="Visible"
+        IsPaneToggleVisible="True"
+        MenuItemsSource="{Binding ViewModel.MenuItems, Mode=OneWay}"
+        PaneDisplayMode="LeftFluent">
+        <ui:NavigationView.Header>
+            <ui:BreadcrumbBar x:Name="BreadcrumbBar" Margin="42,32,42,20" />
+        </ui:NavigationView.Header>
+        <ui:NavigationView.ContentOverlay>
+            <Grid>
+                <ui:SnackbarPresenter x:Name="SnackbarPresenter" />
+            </Grid>
+        </ui:NavigationView.ContentOverlay>
+    </ui:NavigationView>
+</UserControl>

--- a/src/DocFinder.App/Views/Layout/BodyView.xaml.cs
+++ b/src/DocFinder.App/Views/Layout/BodyView.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+using Wpf.Ui.Controls;
+
+namespace DocFinder.App.Views.Layout
+{
+    public partial class BodyView : UserControl
+    {
+        public BodyView()
+        {
+            InitializeComponent();
+        }
+
+        public NavigationView Navigation => RootNavigation;
+    }
+}

--- a/src/DocFinder.App/Views/Layout/FooterView.xaml
+++ b/src/DocFinder.App/Views/Layout/FooterView.xaml
@@ -1,0 +1,11 @@
+<UserControl x:Class="DocFinder.App.Views.Layout.FooterView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    <Border Background="{DynamicResource ApplicationBackgroundBrush}">
+        <ui:TextBlock
+            Margin="12,8"
+            HorizontalAlignment="Center"
+            Text="© 2024 DocFinder" />
+    </Border>
+</UserControl>

--- a/src/DocFinder.App/Views/Layout/FooterView.xaml.cs
+++ b/src/DocFinder.App/Views/Layout/FooterView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace DocFinder.App.Views.Layout
+{
+    public partial class FooterView : UserControl
+    {
+        public FooterView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DocFinder.App/Views/Layout/HeaderBodyFooterLayout.xaml
+++ b/src/DocFinder.App/Views/Layout/HeaderBodyFooterLayout.xaml
@@ -4,11 +4,13 @@
     <Grid Background="{Binding Background, RelativeSource={RelativeSource AncestorType=UserControl}}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <ContentPresenter Grid.Row="0" Content="{Binding Header, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-        <ContentPresenter Grid.Row="1" Content="{Binding Body, RelativeSource={RelativeSource AncestorType=UserControl}}" />
-        <ContentPresenter Grid.Row="2" Content="{Binding Footer, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+        <ContentPresenter Grid.Row="1" Content="{Binding Menu, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+        <ContentPresenter Grid.Row="2" Content="{Binding Body, RelativeSource={RelativeSource AncestorType=UserControl}}" />
+        <ContentPresenter Grid.Row="3" Content="{Binding Footer, RelativeSource={RelativeSource AncestorType=UserControl}}" />
     </Grid>
 </UserControl>

--- a/src/DocFinder.App/Views/Layout/HeaderBodyFooterLayout.xaml.cs
+++ b/src/DocFinder.App/Views/Layout/HeaderBodyFooterLayout.xaml.cs
@@ -14,6 +14,10 @@ namespace DocFinder.App.Views.Layout
             DependencyProperty.Register(
                 nameof(Header), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
 
+        public static readonly DependencyProperty MenuProperty =
+            DependencyProperty.Register(
+                nameof(Menu), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
+
         public static readonly DependencyProperty BodyProperty =
             DependencyProperty.Register(
                 nameof(Body), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
@@ -26,6 +30,12 @@ namespace DocFinder.App.Views.Layout
         {
             get => GetValue(HeaderProperty);
             set => SetValue(HeaderProperty, value);
+        }
+
+        public object? Menu
+        {
+            get => GetValue(MenuProperty);
+            set => SetValue(MenuProperty, value);
         }
 
         public object? Body

--- a/src/DocFinder.App/Views/Layout/HeaderView.xaml
+++ b/src/DocFinder.App/Views/Layout/HeaderView.xaml
@@ -1,0 +1,12 @@
+<UserControl x:Class="DocFinder.App.Views.Layout.HeaderView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    <ui:TitleBar
+        Title="{Binding ViewModel.ApplicationTitle}"
+        CloseWindowByDoubleClickOnIcon="True">
+        <ui:TitleBar.Icon>
+            <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
+        </ui:TitleBar.Icon>
+    </ui:TitleBar>
+</UserControl>

--- a/src/DocFinder.App/Views/Layout/HeaderView.xaml.cs
+++ b/src/DocFinder.App/Views/Layout/HeaderView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace DocFinder.App.Views.Layout
+{
+    public partial class HeaderView : UserControl
+    {
+        public HeaderView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DocFinder.App/Views/Layout/MenuView.xaml
+++ b/src/DocFinder.App/Views/Layout/MenuView.xaml
@@ -1,0 +1,8 @@
+<UserControl x:Class="DocFinder.App.Views.Layout.MenuView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Menu>
+        <MenuItem Header="File" />
+        <MenuItem Header="Edit" />
+    </Menu>
+</UserControl>

--- a/src/DocFinder.App/Views/Layout/MenuView.xaml.cs
+++ b/src/DocFinder.App/Views/Layout/MenuView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace DocFinder.App.Views.Layout
+{
+    public partial class MenuView : UserControl
+    {
+        public MenuView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<ui:FluentWindow
+<ui:FluentWindow
     x:Class="DocFinder.App.Views.Windows.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -25,47 +25,18 @@
     <Grid>
         <layout:HeaderBodyFooterLayout>
             <layout:HeaderBodyFooterLayout.Header>
-                <ui:TitleBar
-                    Title="{Binding ViewModel.ApplicationTitle}"
-                    CloseWindowByDoubleClickOnIcon="True">
-                    <ui:TitleBar.Icon>
-                        <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
-                    </ui:TitleBar.Icon>
-                </ui:TitleBar>
+                <layout:HeaderView />
             </layout:HeaderBodyFooterLayout.Header>
-
+            <layout:HeaderBodyFooterLayout.Menu>
+                <layout:MenuView />
+            </layout:HeaderBodyFooterLayout.Menu>
             <layout:HeaderBodyFooterLayout.Body>
-                <ui:NavigationView
-                    x:Name="RootNavigation"
-                    Padding="42,0,42,0"
-                    BreadcrumbBar="{Binding ElementName=BreadcrumbBar}"
-                    FooterMenuItemsSource="{Binding ViewModel.FooterMenuItems, Mode=OneWay}"
-                    FrameMargin="0"
-                    IsBackButtonVisible="Visible"
-                    IsPaneToggleVisible="True"
-                    MenuItemsSource="{Binding ViewModel.MenuItems, Mode=OneWay}"
-                    PaneDisplayMode="LeftFluent">
-                    <ui:NavigationView.Header>
-                        <ui:BreadcrumbBar x:Name="BreadcrumbBar" Margin="42,32,42,20" />
-                    </ui:NavigationView.Header>
-                    <ui:NavigationView.ContentOverlay>
-                        <Grid>
-                            <ui:SnackbarPresenter x:Name="SnackbarPresenter" />
-                        </Grid>
-                    </ui:NavigationView.ContentOverlay>
-                </ui:NavigationView>
+                <layout:BodyView x:Name="BodyView" />
             </layout:HeaderBodyFooterLayout.Body>
-
             <layout:HeaderBodyFooterLayout.Footer>
-                <Border Background="{DynamicResource ApplicationBackgroundBrush}">
-                    <ui:TextBlock
-                        Margin="12,8"
-                        HorizontalAlignment="Center"
-                        Text="© 2024 DocFinder" />
-                </Border>
+                <layout:FooterView />
             </layout:HeaderBodyFooterLayout.Footer>
         </layout:HeaderBodyFooterLayout>
-
         <ContentPresenter x:Name="RootContentDialog" />
     </Grid>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using DocFinder.App.ViewModels.Windows;
+using DocFinder.App.ViewModels.Windows;
 using Wpf.Ui;
 using Wpf.Ui.Abstractions;
 using Wpf.Ui.Appearance;
@@ -27,16 +27,16 @@ namespace DocFinder.App.Views.Windows
             InitializeComponent();
             SetPageService(navigationViewPageProvider);
 
-            navigationService.SetNavigationControl(RootNavigation);
+            navigationService.SetNavigationControl(BodyView.Navigation);
         }
 
         #region INavigationWindow methods
 
-        public INavigationView GetNavigation() => RootNavigation;
+        public INavigationView GetNavigation() => BodyView.Navigation;
 
-        public bool Navigate(Type pageType) => RootNavigation.Navigate(pageType);
+        public bool Navigate(Type pageType) => BodyView.Navigation.Navigate(pageType);
 
-        public void SetPageService(INavigationViewPageProvider navigationViewPageProvider) => RootNavigation.SetPageProviderService(navigationViewPageProvider);
+        public void SetPageService(INavigationViewPageProvider navigationViewPageProvider) => BodyView.Navigation.SetPageProviderService(navigationViewPageProvider);
 
         public void ShowWindow() => Show();
 


### PR DESCRIPTION
## Summary
- create dedicated views for header, menu, body and footer
- extend layout control with new menu region
- update MainWindow to compose layout from modular parts and route navigation through BodyView

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beaa8463c483268952ff4accb14118