### PR TITLE
Refactor navigation collections to strongly typed model

### DIFF
--- a/src/DocFinder.App/Models/NavigationItem.cs
+++ b/src/DocFinder.App/Models/NavigationItem.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Windows.Controls;
+using Wpf.Ui.Controls;
+
+namespace DocFinder.App.Models
+{
+    public class NavigationItem
+    {
+        public string Title { get; set; } = string.Empty;
+
+        public SymbolRegular Symbol { get; set; }
+
+        public Type TargetPageType { get; set; } = typeof(Page);
+    }
+}

--- a/src/DocFinder.App/ViewModels/Windows/MainWindowViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Windows/MainWindowViewModel.cs
@@ -1,3 +1,4 @@
+using DocFinder.App.Models;
 using DocFinder.App.Views.Pages;
 ﻿using System.Collections.ObjectModel;
 using Wpf.Ui.Controls;
@@ -10,47 +11,47 @@ namespace DocFinder.App.ViewModels.Windows
         private string _applicationTitle = "WPF UI - DocFinder";
 
         [ObservableProperty]
-        private ObservableCollection<object> _menuItems = new()
+        private ObservableCollection<NavigationItem> _menuItems = new()
         {
-            new NavigationViewItem()
+            new()
             {
-                Content = "Home",
-                Icon = new SymbolIcon { Symbol = SymbolRegular.Home24 },
+                Title = "Home",
+                Symbol = SymbolRegular.Home24,
                 TargetPageType = typeof(DashboardPage)
             },
-            new NavigationViewItem()
+            new()
             {
-                Content = "Data",
-                Icon = new SymbolIcon { Symbol = SymbolRegular.DataHistogram24 },
+                Title = "Data",
+                Symbol = SymbolRegular.DataHistogram24,
                 TargetPageType = typeof(DataPage)
             },
-            new NavigationViewItem()
+            new()
             {
-                Content = "Protocols",
-                Icon = new SymbolIcon { Symbol = SymbolRegular.DocumentBulletList24 },
+                Title = "Protocols",
+                Symbol = SymbolRegular.DocumentBulletList24,
                 TargetPageType = typeof(ProtocolsPage)
             },
-            new NavigationViewItem()
+            new()
             {
-                Content = "Files",
-                Icon = new SymbolIcon { Symbol = SymbolRegular.Document24 },
+                Title = "Files",
+                Symbol = SymbolRegular.Document24,
                 TargetPageType = typeof(FilesPage)
             },
-            new NavigationViewItem()
+            new()
             {
-                Content = "Search",
-                Icon = new SymbolIcon { Symbol = SymbolRegular.Search24 },
+                Title = "Search",
+                Symbol = SymbolRegular.Search24,
                 TargetPageType = typeof(SearchPage)
             }
         };
 
         [ObservableProperty]
-        private ObservableCollection<object> _footerMenuItems = new()
+        private ObservableCollection<NavigationItem> _footerMenuItems = new()
         {
-            new NavigationViewItem()
+            new()
             {
-                Content = "Settings",
-                Icon = new SymbolIcon { Symbol = SymbolRegular.Settings24 },
+                Title = "Settings",
+                Symbol = SymbolRegular.Settings24,
                 TargetPageType = typeof(SettingsPage)
             }
         };

--- a/src/DocFinder.App/Views/Layout/BodyView.xaml
+++ b/src/DocFinder.App/Views/Layout/BodyView.xaml
@@ -1,16 +1,28 @@
 <UserControl x:Class="DocFinder.App.Views.Layout.BodyView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             xmlns:models="clr-namespace:DocFinder.App.Models">
+    <UserControl.Resources>
+        <DataTemplate x:Key="NavigationItemTemplate" DataType="{x:Type models:NavigationItem}">
+            <ui:NavigationViewItem Content="{Binding Title}" TargetPageType="{Binding TargetPageType}">
+                <ui:NavigationViewItem.Icon>
+                    <ui:SymbolIcon Symbol="{Binding Symbol}" />
+                </ui:NavigationViewItem.Icon>
+            </ui:NavigationViewItem>
+        </DataTemplate>
+    </UserControl.Resources>
     <ui:NavigationView
         x:Name="RootNavigation"
         Padding="42,0,42,0"
         BreadcrumbBar="{Binding ElementName=BreadcrumbBar}"
         FooterMenuItemsSource="{Binding ViewModel.FooterMenuItems, Mode=OneWay}"
+        FooterMenuItemTemplate="{StaticResource NavigationItemTemplate}"
         FrameMargin="0"
         IsBackButtonVisible="Visible"
         IsPaneToggleVisible="True"
         MenuItemsSource="{Binding ViewModel.MenuItems, Mode=OneWay}"
+        MenuItemTemplate="{StaticResource NavigationItemTemplate}"
         PaneDisplayMode="LeftFluent">
         <ui:NavigationView.Header>
             <ui:BreadcrumbBar x:Name="BreadcrumbBar" Margin="42,32,42,20" />


### PR DESCRIPTION
## Summary
- add `NavigationItem` model for navigation metadata
- update `MainWindowViewModel` to use `ObservableCollection<NavigationItem>`
- template navigation items in `BodyView.xaml` via bindings

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj --no-build` *(tests started, two skipped; execution did not complete and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68beb2ec3ac8832696aeb7ec21551c35