### PR TITLE
Use WPF UI menu items with commands

### DIFF
--- a/src/DocFinder.App/ViewModels/Windows/MainWindowViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Windows/MainWindowViewModel.cs
@@ -61,5 +61,17 @@ namespace DocFinder.App.ViewModels.Windows
         {
             new MenuItem { Header = "Home", Tag = "tray_home" }
         };
+
+        [RelayCommand]
+        private void OpenFile()
+        {
+            // TODO: Implement file open logic
+        }
+
+        [RelayCommand]
+        private void EditItem()
+        {
+            // TODO: Implement edit logic
+        }
     }
 }

--- a/src/DocFinder.App/Views/Layout/MenuView.xaml
+++ b/src/DocFinder.App/Views/Layout/MenuView.xaml
@@ -1,8 +1,9 @@
 <UserControl x:Class="DocFinder.App.Views.Layout.MenuView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
     <Menu>
-        <MenuItem Header="File" />
-        <MenuItem Header="Edit" />
+        <ui:MenuItem Header="File" Command="{Binding OpenFileCommand}" />
+        <ui:MenuItem Header="Edit" Command="{Binding EditItemCommand}" />
     </Menu>
 </UserControl>


### PR DESCRIPTION
## Summary
- Replace top menu items with WPF UI `MenuItem` controls
- Bind File and Edit menu items to new commands in `MainWindowViewModel`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj` *(hangs after running and skipping tests; process required manual cancel)*

------
https://chatgpt.com/codex/tasks/task_e_68beb80cf59c832689cabda81198064a