### PR TITLE
Store service provider in MainWindow

### DIFF
--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
@@ -10,6 +10,8 @@ namespace DocFinder.App.Views.Windows
     {
         public MainWindowViewModel? ViewModel { get; }
 
+        private IServiceProvider? _serviceProvider;
+
         public MainWindow()
         {
             SystemThemeWatcher.Watch(this);
@@ -55,9 +57,6 @@ namespace DocFinder.App.Views.Windows
             System.Windows.Application.Current.Shutdown();
         }
 
-        public void SetServiceProvider(IServiceProvider serviceProvider)
-        {
-            throw new NotImplementedException();
-        }
+        public void SetServiceProvider(IServiceProvider serviceProvider) => _serviceProvider = serviceProvider;
     }
 }


### PR DESCRIPTION
## Summary
- Capture IServiceProvider in MainWindow for potential dependency resolution

## Testing
- `dotnet build DocFinder.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beba6d52888326ba77da52e12bed84