### PR TITLE
Initialize MainWindow in default constructor

### DIFF
--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
@@ -12,6 +12,7 @@ namespace DocFinder.App.Views.Windows
 
         public MainWindow()
         {
+            InitializeComponent();
             SystemThemeWatcher.Watch(this);
         }
 
@@ -23,8 +24,6 @@ namespace DocFinder.App.Views.Windows
         {
             ViewModel = viewModel;
             DataContext = this;
-
-            InitializeComponent();
             SetPageService(navigationViewPageProvider);
 
             navigationService.SetNavigationControl(BodyView.Navigation);


### PR DESCRIPTION
## Summary
- ensure `MainWindow` initializes its components in parameterless constructor
- avoid duplicate initialization when using dependency injection

## Testing
- `dotnet test` *(fails: canceled after hanging while running tests)*
- `dotnet build` *(fails: WPF build errors, tag references missing)*

------
https://chatgpt.com/codex/tasks/task_e_68beba6e8da08326af912a70c2108687