### PR TITLE
Refactor pages to unified layout using WPF UI

### DIFF
--- a/src/DocFinder.App/Views/Pages/DashboardPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DashboardPage.xaml
@@ -1,12 +1,12 @@
-﻿<Page
+<ui:Page
     x:Class="DocFinder.App.Views.Pages.DashboardPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="DashboardPage"
     d:DataContext="{d:DesignInstance vm:DashboardViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
@@ -16,21 +16,35 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <Grid VerticalAlignment="Top">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <layout:HeaderView />
+        </layout:HeaderBodyFooterLayout.Header>
+        <layout:HeaderBodyFooterLayout.Menu>
+            <layout:MenuView />
+        </layout:HeaderBodyFooterLayout.Menu>
+        <layout:HeaderBodyFooterLayout.Body>
+            <Grid VerticalAlignment="Top">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
 
-        <ui:Button
-            Grid.Column="0"
-            Command="{Binding ViewModel.CounterIncrementCommand, Mode=OneWay}"
-            Content="Click me!"
-            Icon="Fluent24" />
-        <TextBlock
-            Grid.Column="1"
-            Margin="12,0,0,0"
-            VerticalAlignment="Center"
-            Text="{Binding ViewModel.Counter, Mode=OneWay}" />
-    </Grid>
-</Page>
+                <ui:Button
+                    Grid.Column="0"
+                    Command="{Binding ViewModel.CounterIncrementCommand, Mode=OneWay}"
+                    Content="Click me!"
+                    Icon="Fluent24" />
+                <TextBlock
+                    Grid.Column="1"
+                    Margin="12,0,0,0"
+                    VerticalAlignment="Center"
+                    Text="{Binding ViewModel.Counter, Mode=OneWay}" />
+            </Grid>
+        </layout:HeaderBodyFooterLayout.Body>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <layout:FooterView />
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
+</ui:Page>
+

--- a/src/DocFinder.App/Views/Pages/DataPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DataPage.xaml
@@ -1,13 +1,12 @@
-<Page
+<ui:Page
     x:Class="DocFinder.App.Views.Pages.DataPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="clr-namespace:DocFinder.App.Models"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="DataPage"
     d:DataContext="{d:DesignInstance vm:DataViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
@@ -15,29 +14,23 @@
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-    ScrollViewer.CanContentScroll="False"
     mc:Ignorable="d">
 
-    <Grid>
-        <ui:VirtualizingItemsControl
-            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-            ItemsSource="{Binding ViewModel.Colors, Mode=OneWay}"
-            VirtualizingPanel.CacheLengthUnit="Item">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate DataType="{x:Type models:DataColor}">
-                    <ui:Button
-                        Width="80"
-                        Height="80"
-                        Margin="2"
-                        Padding="0"
-                        HorizontalAlignment="Stretch"
-                        VerticalAlignment="Stretch"
-                        Appearance="Secondary"
-                        Background="{Binding Color, Mode=OneWay}"
-                        FontSize="25"
-                        Icon="Fluent24" />
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ui:VirtualizingItemsControl>
-    </Grid>
-</Page>
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <layout:HeaderView />
+        </layout:HeaderBodyFooterLayout.Header>
+        <layout:HeaderBodyFooterLayout.Menu>
+            <layout:MenuView />
+        </layout:HeaderBodyFooterLayout.Menu>
+        <layout:HeaderBodyFooterLayout.Body>
+            <Grid>
+                <ui:Card ControlMargin="12" Title="Data overview" />
+            </Grid>
+        </layout:HeaderBodyFooterLayout.Body>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <layout:FooterView />
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
+</ui:Page>
+

--- a/src/DocFinder.App/Views/Pages/FileDetailPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FileDetailPage.xaml
@@ -1,14 +1,14 @@
-<Page
+<ui:Page
     x:Class="DocFinder.App.Views.Pages.FileDetailPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:entities="clr-namespace:DocFinder.App.ViewModels.Entities"
+    xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="FileDetailPage"
-    d:DataContext="{d:DesignInstance entities:FileViewModel, IsDesignTimeCreatable=False}"
+    d:DataContext="{d:DesignInstance vm:FilesViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
     d:DesignWidth="800"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
@@ -16,12 +16,24 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <ScrollViewer>
-        <StackPanel Margin="20" DataContext="{Binding ViewModel}">
-            <TextBlock Text="{Binding Name}" FontSize="20" FontWeight="Bold" />
-            <TextBlock Text="{Binding Ext}" Margin="0,5,0,0" />
-            <TextBlock Text="{Binding Author}" Margin="0,5,0,0" />
-            <TextBlock Text="{Binding SizeBytes}" Margin="0,5,0,0" />
-        </StackPanel>
-    </ScrollViewer>
-</Page>
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <layout:HeaderView />
+        </layout:HeaderBodyFooterLayout.Header>
+        <layout:HeaderBodyFooterLayout.Menu>
+            <layout:MenuView />
+        </layout:HeaderBodyFooterLayout.Menu>
+        <layout:HeaderBodyFooterLayout.Body>
+            <StackPanel Margin="12">
+                <TextBlock FontSize="20" FontWeight="Medium" Text="File details" />
+                <ui:Separator Margin="0,8" />
+                <TextBlock Text="{Binding ViewModel.SelectedFile.Name}" />
+                <TextBlock Text="{Binding ViewModel.SelectedFile.Path}" />
+            </StackPanel>
+        </layout:HeaderBodyFooterLayout.Body>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <layout:FooterView />
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
+</ui:Page>
+

--- a/src/DocFinder.App/Views/Pages/FilesPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FilesPage.xaml
@@ -1,12 +1,12 @@
-<Page
+<ui:Page
     x:Class="DocFinder.App.Views.Pages.FilesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="FilesPage"
     d:DataContext="{d:DesignInstance vm:FilesViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
@@ -16,23 +16,37 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <Grid>
-        <ListView ItemsSource="{Binding ViewModel.Files}">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Border Margin="4" Padding="8" BorderThickness="1" CornerRadius="4" BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}">
-                        <StackPanel>
-                            <TextBlock Text="{Binding Name}" FontWeight="Bold" />
-                            <TextBlock Text="{Binding Ext}" FontSize="12" />
-                        </StackPanel>
-                    </Border>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-            <ListView.ItemContainerStyle>
-                <Style TargetType="ListViewItem">
-                    <EventSetter Event="MouseDoubleClick" Handler="OnFileDoubleClick" />
-                </Style>
-            </ListView.ItemContainerStyle>
-        </ListView>
-    </Grid>
-</Page>
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <layout:HeaderView />
+        </layout:HeaderBodyFooterLayout.Header>
+        <layout:HeaderBodyFooterLayout.Menu>
+            <layout:MenuView />
+        </layout:HeaderBodyFooterLayout.Menu>
+        <layout:HeaderBodyFooterLayout.Body>
+            <Grid>
+                <ListView ItemsSource="{Binding ViewModel.Files}">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <Border Margin="4" Padding="8" BorderThickness="1" CornerRadius="4" BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}">
+                                <StackPanel>
+                                    <TextBlock Text="{Binding Name}" FontWeight="Bold" />
+                                    <TextBlock Text="{Binding Ext}" FontSize="12" />
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <EventSetter Event="MouseDoubleClick" Handler="OnFileDoubleClick" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                </ListView>
+            </Grid>
+        </layout:HeaderBodyFooterLayout.Body>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <layout:FooterView />
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
+</ui:Page>
+

--- a/src/DocFinder.App/Views/Pages/ProtocolDetailPage.xaml
+++ b/src/DocFinder.App/Views/Pages/ProtocolDetailPage.xaml
@@ -1,14 +1,14 @@
-<Page
+<ui:Page
     x:Class="DocFinder.App.Views.Pages.ProtocolDetailPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:entities="clr-namespace:DocFinder.App.ViewModels.Entities"
+    xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="ProtocolDetailPage"
-    d:DataContext="{d:DesignInstance entities:ProtocolViewModel, IsDesignTimeCreatable=False}"
+    d:DataContext="{d:DesignInstance vm:ProtocolsViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
     d:DesignWidth="800"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
@@ -16,12 +16,24 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <ScrollViewer>
-        <StackPanel Margin="20" DataContext="{Binding ViewModel}">
-            <TextBlock Text="{Binding Title}" FontSize="20" FontWeight="Bold" />
-            <TextBlock Text="{Binding ReferenceNumber}" Margin="0,5,0,0" />
-            <TextBlock Text="{Binding IssuedBy}" Margin="0,5,0,0" />
-            <TextBlock Text="{Binding ResponsiblePerson}" Margin="0,5,0,0" />
-        </StackPanel>
-    </ScrollViewer>
-</Page>
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <layout:HeaderView />
+        </layout:HeaderBodyFooterLayout.Header>
+        <layout:HeaderBodyFooterLayout.Menu>
+            <layout:MenuView />
+        </layout:HeaderBodyFooterLayout.Menu>
+        <layout:HeaderBodyFooterLayout.Body>
+            <StackPanel Margin="12">
+                <TextBlock FontSize="20" FontWeight="Medium" Text="Protocol details" />
+                <ui:Separator Margin="0,8" />
+                <TextBlock Text="{Binding ViewModel.SelectedProtocol.Name}" />
+                <TextBlock Text="{Binding ViewModel.SelectedProtocol.Description}" />
+            </StackPanel>
+        </layout:HeaderBodyFooterLayout.Body>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <layout:FooterView />
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
+</ui:Page>
+

--- a/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
@@ -1,12 +1,12 @@
-<Page
+<ui:Page
     x:Class="DocFinder.App.Views.Pages.ProtocolsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="ProtocolsPage"
     d:DataContext="{d:DesignInstance vm:ProtocolsViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
@@ -16,23 +16,21 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <Grid>
-        <ListView ItemsSource="{Binding ViewModel.Protocols}">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Border Margin="4" Padding="8" BorderThickness="1" CornerRadius="4" BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}">
-                        <StackPanel>
-                            <TextBlock Text="{Binding Title}" FontWeight="Bold" />
-                            <TextBlock Text="{Binding ReferenceNumber}" FontSize="12" />
-                        </StackPanel>
-                    </Border>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-            <ListView.ItemContainerStyle>
-                <Style TargetType="ListViewItem">
-                    <EventSetter Event="MouseDoubleClick" Handler="OnProtocolDoubleClick" />
-                </Style>
-            </ListView.ItemContainerStyle>
-        </ListView>
-    </Grid>
-</Page>
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <layout:HeaderView />
+        </layout:HeaderBodyFooterLayout.Header>
+        <layout:HeaderBodyFooterLayout.Menu>
+            <layout:MenuView />
+        </layout:HeaderBodyFooterLayout.Menu>
+        <layout:HeaderBodyFooterLayout.Body>
+            <Grid>
+                <ui:Card ControlMargin="12" Title="Protocols" />
+            </Grid>
+        </layout:HeaderBodyFooterLayout.Body>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <layout:FooterView />
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
+</ui:Page>
+

--- a/src/DocFinder.App/Views/Pages/SearchPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SearchPage.xaml
@@ -1,4 +1,4 @@
-<Page
+<ui:Page
     x:Class="DocFinder.App.Views.Pages.SearchPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,6 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="SearchPage"
     d:DataContext="{d:DesignInstance vm:SearchViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
@@ -15,7 +16,28 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <Grid>
-        <TextBlock Text="Search page" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-    </Grid>
-</Page>
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <layout:HeaderView />
+        </layout:HeaderBodyFooterLayout.Header>
+        <layout:HeaderBodyFooterLayout.Menu>
+            <layout:MenuView />
+        </layout:HeaderBodyFooterLayout.Menu>
+        <layout:HeaderBodyFooterLayout.Body>
+            <Grid>
+                <ui:TextBox
+                    Margin="0,0,0,12"
+                    PlaceholderText="Search files..."
+                    Text="{Binding ViewModel.SearchQuery, Mode=TwoWay}" />
+                <ui:Button
+                    Margin="0,40,0,0"
+                    Command="{Binding ViewModel.SearchCommand}"
+                    Content="Search" />
+            </Grid>
+        </layout:HeaderBodyFooterLayout.Body>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <layout:FooterView />
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
+</ui:Page>
+

--- a/src/DocFinder.App/Views/Pages/SettingsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SettingsPage.xaml
@@ -1,13 +1,13 @@
-﻿<Page
+<ui:Page
     x:Class="DocFinder.App.Views.Pages.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:helpers="clr-namespace:DocFinder.App.Helpers"
-    xmlns:local="clr-namespace:DocFinder.App.Views.Pages"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:helpers="clr-namespace:DocFinder.App.Helpers"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="SettingsPage"
     d:DataContext="{d:DesignInstance vm:SettingsViewModel, IsDesignTimeCreatable=False}"
     d:DesignHeight="450"
@@ -16,36 +16,50 @@
     ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
-    <Page.Resources>
+    <ui:Page.Resources>
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
-    </Page.Resources>
+    </ui:Page.Resources>
 
-    <StackPanel>
-        <TextBlock
-            FontSize="20"
-            FontWeight="Medium"
-            Text="Personalization" />
-        <TextBlock Margin="0,12,0,0" Text="Theme" />
-        <RadioButton
-            Margin="0,12,0,0"
-            Command="{Binding ViewModel.ChangeThemeCommand, Mode=OneWay}"
-            CommandParameter="theme_light"
-            Content="Light"
-            GroupName="themeSelect"
-            IsChecked="{Binding ViewModel.CurrentTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Light, Mode=OneWay}" />
-        <RadioButton
-            Margin="0,8,0,0"
-            Command="{Binding ViewModel.ChangeThemeCommand, Mode=OneWay}"
-            CommandParameter="theme_dark"
-            Content="Dark"
-            GroupName="themeSelect"
-            IsChecked="{Binding ViewModel.CurrentTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}" />
+    <layout:HeaderBodyFooterLayout>
+        <layout:HeaderBodyFooterLayout.Header>
+            <layout:HeaderView />
+        </layout:HeaderBodyFooterLayout.Header>
+        <layout:HeaderBodyFooterLayout.Menu>
+            <layout:MenuView />
+        </layout:HeaderBodyFooterLayout.Menu>
+        <layout:HeaderBodyFooterLayout.Body>
+            <StackPanel>
+                <TextBlock
+                    FontSize="20"
+                    FontWeight="Medium"
+                    Text="Personalization" />
+                <TextBlock Margin="0,12,0,0" Text="Theme" />
+                <RadioButton
+                    Margin="0,12,0,0"
+                    Command="{Binding ViewModel.ChangeThemeCommand, Mode=OneWay}"
+                    CommandParameter="theme_light"
+                    Content="Light"
+                    GroupName="themeSelect"
+                    IsChecked="{Binding ViewModel.CurrentTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Light, Mode=OneWay}" />
+                <RadioButton
+                    Margin="0,8,0,0"
+                    Command="{Binding ViewModel.ChangeThemeCommand, Mode=OneWay}"
+                    CommandParameter="theme_dark"
+                    Content="Dark"
+                    GroupName="themeSelect"
+                    IsChecked="{Binding ViewModel.CurrentTheme, Converter={StaticResource EnumToBooleanConverter}, ConverterParameter=Dark, Mode=OneWay}" />
 
-        <TextBlock
-            Margin="0,24,0,0"
-            FontSize="20"
-            FontWeight="Medium"
-            Text="About DocFinder" />
-        <TextBlock Margin="0,12,0,0" Text="{Binding ViewModel.AppVersion, Mode=OneWay}" />
-    </StackPanel>
-</Page>
+                <TextBlock
+                    Margin="0,24,0,0"
+                    FontSize="20"
+                    FontWeight="Medium"
+                    Text="About DocFinder" />
+                <TextBlock Margin="0,12,0,0" Text="{Binding ViewModel.AppVersion, Mode=OneWay}" />
+            </StackPanel>
+        </layout:HeaderBodyFooterLayout.Body>
+        <layout:HeaderBodyFooterLayout.Footer>
+            <layout:FooterView />
+        </layout:HeaderBodyFooterLayout.Footer>
+    </layout:HeaderBodyFooterLayout>
+</ui:Page>
+


### PR DESCRIPTION
## Summary
- refactor page XAMLs to use WPF UI `Page` and new `HeaderBodyFooterLayout`
- ensure each page composes header, menu, body and footer consistently

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec331af588326a3b6c7c9b8561b28