### PR TITLE
Rename HeaderBodyFooterLayout to MainLayout

### DIFF
--- a/src/DocFinder.App/Views/Layout/MainLayout.xaml
+++ b/src/DocFinder.App/Views/Layout/MainLayout.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="DocFinder.App.Views.Layout.HeaderBodyFooterLayout"
+<UserControl x:Class="DocFinder.App.Views.Layout.MainLayout"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Grid Background="{Binding Background, RelativeSource={RelativeSource AncestorType=UserControl}}">

--- a/src/DocFinder.App/Views/Layout/MainLayout.xaml.cs
+++ b/src/DocFinder.App/Views/Layout/MainLayout.xaml.cs
@@ -3,28 +3,28 @@ using System.Windows.Controls;
 
 namespace DocFinder.App.Views.Layout
 {
-    public partial class HeaderBodyFooterLayout : UserControl
+    public partial class MainLayout : UserControl
     {
-        public HeaderBodyFooterLayout()
+        public MainLayout()
         {
             InitializeComponent();
         }
 
         public static readonly DependencyProperty HeaderProperty =
             DependencyProperty.Register(
-                nameof(Header), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
+                nameof(Header), typeof(object), typeof(MainLayout), new PropertyMetadata(null));
 
         public static readonly DependencyProperty MenuProperty =
             DependencyProperty.Register(
-                nameof(Menu), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
+                nameof(Menu), typeof(object), typeof(MainLayout), new PropertyMetadata(null));
 
         public static readonly DependencyProperty BodyProperty =
             DependencyProperty.Register(
-                nameof(Body), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
+                nameof(Body), typeof(object), typeof(MainLayout), new PropertyMetadata(null));
 
         public static readonly DependencyProperty FooterProperty =
             DependencyProperty.Register(
-                nameof(Footer), typeof(object), typeof(HeaderBodyFooterLayout), new PropertyMetadata(null));
+                nameof(Footer), typeof(object), typeof(MainLayout), new PropertyMetadata(null));
 
         public object? Header
         {

--- a/src/DocFinder.App/Views/Pages/DashboardPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DashboardPage.xaml
@@ -16,14 +16,14 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <layout:HeaderView />
-        </layout:HeaderBodyFooterLayout.Header>
-        <layout:HeaderBodyFooterLayout.Menu>
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
             <layout:MenuView />
-        </layout:HeaderBodyFooterLayout.Menu>
-        <layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
             <Grid VerticalAlignment="Top">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -41,10 +41,10 @@
                     VerticalAlignment="Center"
                     Text="{Binding ViewModel.Counter, Mode=OneWay}" />
             </Grid>
-        </layout:HeaderBodyFooterLayout.Body>
-        <layout:HeaderBodyFooterLayout.Footer>
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
             <layout:FooterView />
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:Page>
 

--- a/src/DocFinder.App/Views/Pages/DataPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DataPage.xaml
@@ -16,21 +16,21 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <layout:HeaderView />
-        </layout:HeaderBodyFooterLayout.Header>
-        <layout:HeaderBodyFooterLayout.Menu>
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
             <layout:MenuView />
-        </layout:HeaderBodyFooterLayout.Menu>
-        <layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
             <Grid>
                 <ui:Card ControlMargin="12" Title="Data overview" />
             </Grid>
-        </layout:HeaderBodyFooterLayout.Body>
-        <layout:HeaderBodyFooterLayout.Footer>
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
             <layout:FooterView />
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:Page>
 

--- a/src/DocFinder.App/Views/Pages/FileDetailPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FileDetailPage.xaml
@@ -16,24 +16,24 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <layout:HeaderView />
-        </layout:HeaderBodyFooterLayout.Header>
-        <layout:HeaderBodyFooterLayout.Menu>
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
             <layout:MenuView />
-        </layout:HeaderBodyFooterLayout.Menu>
-        <layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
             <StackPanel Margin="12">
                 <TextBlock FontSize="20" FontWeight="Medium" Text="File details" />
                 <ui:Separator Margin="0,8" />
                 <TextBlock Text="{Binding ViewModel.SelectedFile.Name}" />
                 <TextBlock Text="{Binding ViewModel.SelectedFile.Path}" />
             </StackPanel>
-        </layout:HeaderBodyFooterLayout.Body>
-        <layout:HeaderBodyFooterLayout.Footer>
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
             <layout:FooterView />
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:Page>
 

--- a/src/DocFinder.App/Views/Pages/FilesPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FilesPage.xaml
@@ -16,14 +16,14 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <layout:HeaderView />
-        </layout:HeaderBodyFooterLayout.Header>
-        <layout:HeaderBodyFooterLayout.Menu>
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
             <layout:MenuView />
-        </layout:HeaderBodyFooterLayout.Menu>
-        <layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
             <Grid>
                 <ListView ItemsSource="{Binding ViewModel.Files}">
                     <ListView.ItemTemplate>
@@ -43,10 +43,10 @@
                     </ListView.ItemContainerStyle>
                 </ListView>
             </Grid>
-        </layout:HeaderBodyFooterLayout.Body>
-        <layout:HeaderBodyFooterLayout.Footer>
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
             <layout:FooterView />
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:Page>
 

--- a/src/DocFinder.App/Views/Pages/ProtocolDetailPage.xaml
+++ b/src/DocFinder.App/Views/Pages/ProtocolDetailPage.xaml
@@ -16,24 +16,24 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <layout:HeaderView />
-        </layout:HeaderBodyFooterLayout.Header>
-        <layout:HeaderBodyFooterLayout.Menu>
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
             <layout:MenuView />
-        </layout:HeaderBodyFooterLayout.Menu>
-        <layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
             <StackPanel Margin="12">
                 <TextBlock FontSize="20" FontWeight="Medium" Text="Protocol details" />
                 <ui:Separator Margin="0,8" />
                 <TextBlock Text="{Binding ViewModel.SelectedProtocol.Name}" />
                 <TextBlock Text="{Binding ViewModel.SelectedProtocol.Description}" />
             </StackPanel>
-        </layout:HeaderBodyFooterLayout.Body>
-        <layout:HeaderBodyFooterLayout.Footer>
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
             <layout:FooterView />
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:Page>
 

--- a/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
@@ -16,21 +16,21 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <layout:HeaderView />
-        </layout:HeaderBodyFooterLayout.Header>
-        <layout:HeaderBodyFooterLayout.Menu>
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
             <layout:MenuView />
-        </layout:HeaderBodyFooterLayout.Menu>
-        <layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
             <Grid>
                 <ui:Card ControlMargin="12" Title="Protocols" />
             </Grid>
-        </layout:HeaderBodyFooterLayout.Body>
-        <layout:HeaderBodyFooterLayout.Footer>
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
             <layout:FooterView />
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:Page>
 

--- a/src/DocFinder.App/Views/Pages/SearchPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SearchPage.xaml
@@ -16,14 +16,14 @@
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
 
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <layout:HeaderView />
-        </layout:HeaderBodyFooterLayout.Header>
-        <layout:HeaderBodyFooterLayout.Menu>
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
             <layout:MenuView />
-        </layout:HeaderBodyFooterLayout.Menu>
-        <layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
             <Grid>
                 <ui:TextBox
                     Margin="0,0,0,12"
@@ -34,10 +34,10 @@
                     Command="{Binding ViewModel.SearchCommand}"
                     Content="Search" />
             </Grid>
-        </layout:HeaderBodyFooterLayout.Body>
-        <layout:HeaderBodyFooterLayout.Footer>
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
             <layout:FooterView />
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:Page>
 

--- a/src/DocFinder.App/Views/Pages/SettingsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SettingsPage.xaml
@@ -20,14 +20,14 @@
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
     </ui:Page.Resources>
 
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <layout:HeaderView />
-        </layout:HeaderBodyFooterLayout.Header>
-        <layout:HeaderBodyFooterLayout.Menu>
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
             <layout:MenuView />
-        </layout:HeaderBodyFooterLayout.Menu>
-        <layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
             <StackPanel>
                 <TextBlock
                     FontSize="20"
@@ -56,10 +56,10 @@
                     Text="About DocFinder" />
                 <TextBlock Margin="0,12,0,0" Text="{Binding ViewModel.AppVersion, Mode=OneWay}" />
             </StackPanel>
-        </layout:HeaderBodyFooterLayout.Body>
-        <layout:HeaderBodyFooterLayout.Footer>
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
             <layout:FooterView />
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:Page>
 

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -11,28 +11,28 @@
     WindowStyle="None"
     ResizeMode="NoResize"
     ShowInTaskbar="False">
-    <layout:HeaderBodyFooterLayout Background="{DynamicResource SurfaceBackgroundBrush}">
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout Background="{DynamicResource SurfaceBackgroundBrush}">
+        <layout:MainLayout.Header>
             <ui:TitleBar Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}">
                 <ui:TitleBar.Icon>
                     <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
                 </ui:TitleBar.Icon>
             </ui:TitleBar>
-        </layout:HeaderBodyFooterLayout.Header>
+        </layout:MainLayout.Header>
 
-        <layout:HeaderBodyFooterLayout.Body>
+        <layout:MainLayout.Body>
             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="Načítání…" FontSize="16" Margin="0,0,0,12" HorizontalAlignment="Center"
                            Foreground="{DynamicResource TextPrimaryBrush}"/>
                 <ProgressBar IsIndeterminate="True" Width="200" Height="20"
                              Foreground="{DynamicResource AccentBrush}"/>
             </StackPanel>
-        </layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Body>
 
-        <layout:HeaderBodyFooterLayout.Footer>
+        <layout:MainLayout.Footer>
             <Border Background="{DynamicResource ApplicationBackgroundBrush}">
                 <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
             </Border>
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml
@@ -23,20 +23,20 @@
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
     <Grid>
-        <layout:HeaderBodyFooterLayout>
-            <layout:HeaderBodyFooterLayout.Header>
+        <layout:MainLayout>
+            <layout:MainLayout.Header>
                 <layout:HeaderView />
-            </layout:HeaderBodyFooterLayout.Header>
-            <layout:HeaderBodyFooterLayout.Menu>
+            </layout:MainLayout.Header>
+            <layout:MainLayout.Menu>
                 <layout:MenuView />
-            </layout:HeaderBodyFooterLayout.Menu>
-            <layout:HeaderBodyFooterLayout.Body>
+            </layout:MainLayout.Menu>
+            <layout:MainLayout.Body>
                 <layout:BodyView x:Name="BodyView" />
-            </layout:HeaderBodyFooterLayout.Body>
-            <layout:HeaderBodyFooterLayout.Footer>
+            </layout:MainLayout.Body>
+            <layout:MainLayout.Footer>
                 <layout:FooterView />
-            </layout:HeaderBodyFooterLayout.Footer>
-        </layout:HeaderBodyFooterLayout>
+            </layout:MainLayout.Footer>
+        </layout:MainLayout>
         <ContentPresenter x:Name="RootContentDialog" />
     </Grid>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
+++ b/src/DocFinder.App/Views/Windows/SearchOverlay.xaml
@@ -64,16 +64,16 @@
             </Style>
         </ResourceDictionary>
     </ui:FluentWindow.Resources>
-    <layout:HeaderBodyFooterLayout Background="{DynamicResource SurfaceBackgroundBrush}">
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout Background="{DynamicResource SurfaceBackgroundBrush}">
+        <layout:MainLayout.Header>
             <ui:TitleBar Title="DocFinder" Foreground="{DynamicResource TextPrimaryBrush}">
                 <ui:TitleBar.Icon>
                     <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
                 </ui:TitleBar.Icon>
             </ui:TitleBar>
-        </layout:HeaderBodyFooterLayout.Header>
+        </layout:MainLayout.Header>
 
-        <layout:HeaderBodyFooterLayout.Body>
+        <layout:MainLayout.Body>
             <Grid Margin="{StaticResource Space24}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
@@ -208,12 +208,12 @@
                 </Grid>
             </Grid>
         </Grid>
-        </layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Body>
 
-        <layout:HeaderBodyFooterLayout.Footer>
+        <layout:MainLayout.Footer>
             <Border Background="{DynamicResource ApplicationBackgroundBrush}">
                 <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
             </Border>
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/SettingsWindow.xaml
@@ -8,16 +8,16 @@
     ExtendsContentIntoTitleBar="True"
     WindowBackdropType="Mica"
     ResizeMode="CanResize">
-    <layout:HeaderBodyFooterLayout>
-        <layout:HeaderBodyFooterLayout.Header>
+    <layout:MainLayout>
+        <layout:MainLayout.Header>
             <ui:TitleBar Title="Settings" Foreground="{DynamicResource TextFillColorPrimaryBrush}">
                 <ui:TitleBar.Icon>
                     <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png" />
                 </ui:TitleBar.Icon>
             </ui:TitleBar>
-        </layout:HeaderBodyFooterLayout.Header>
+        </layout:MainLayout.Header>
 
-        <layout:HeaderBodyFooterLayout.Body>
+        <layout:MainLayout.Body>
             <StackPanel Margin="20">
                 <TextBlock Text="Source Folder"/>
                 <TextBox Text="{Binding Settings.SourceRoot, UpdateSourceTrigger=PropertyChanged}"/>
@@ -47,12 +47,12 @@
                     </DataGrid.Columns>
                 </DataGrid>
             </StackPanel>
-        </layout:HeaderBodyFooterLayout.Body>
+        </layout:MainLayout.Body>
 
-        <layout:HeaderBodyFooterLayout.Footer>
+        <layout:MainLayout.Footer>
             <Border Background="{DynamicResource ApplicationBackgroundBrush}">
                 <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
             </Border>
-        </layout:HeaderBodyFooterLayout.Footer>
-    </layout:HeaderBodyFooterLayout>
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:FluentWindow>


### PR DESCRIPTION
## Summary
- rename the awkward `HeaderBodyFooterLayout` to `MainLayout`
- update all pages and windows to reference `MainLayout`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bec6a02b4c832684b3e44619c66a32