### PR TITLE
Replace MainWindow content with MainLayout

### DIFF
--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml
@@ -22,21 +22,18 @@
     WindowCornerPreference="Round"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">
-    <Grid>
-        <layout:MainLayout>
-            <layout:MainLayout.Header>
-                <layout:HeaderView />
-            </layout:MainLayout.Header>
-            <layout:MainLayout.Menu>
-                <layout:MenuView />
-            </layout:MainLayout.Menu>
-            <layout:MainLayout.Body>
-                <layout:BodyView x:Name="BodyView" />
-            </layout:MainLayout.Body>
-            <layout:MainLayout.Footer>
-                <layout:FooterView />
-            </layout:MainLayout.Footer>
-        </layout:MainLayout>
-        <ContentPresenter x:Name="RootContentDialog" />
-    </Grid>
+    <layout:MainLayout x:Name="MainLayout">
+        <layout:MainLayout.Header>
+            <layout:HeaderView />
+        </layout:MainLayout.Header>
+        <layout:MainLayout.Menu>
+            <layout:MenuView />
+        </layout:MainLayout.Menu>
+        <layout:MainLayout.Body>
+            <layout:BodyView x:Name="BodyView" />
+        </layout:MainLayout.Body>
+        <layout:MainLayout.Footer>
+            <layout:FooterView />
+        </layout:MainLayout.Footer>
+    </layout:MainLayout>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
 using DocFinder.App.ViewModels.Windows;
+using DocFinder.App.Views.Layout;
 using Wpf.Ui;
 using Wpf.Ui.Abstractions;
 using Wpf.Ui.Appearance;
@@ -9,6 +10,8 @@ namespace DocFinder.App.Views.Windows
     public partial class MainWindow : FluentWindow, INavigationWindow
     {
         public MainWindowViewModel? ViewModel { get; }
+
+        public MainLayout MainLayoutControl => MainLayout;
 
         private IServiceProvider? _serviceProvider;
 


### PR DESCRIPTION
## Summary
- Switch MainWindow to use shared MainLayout with header, menu, body and footer slots
- Expose MainLayout control from code-behind for runtime interaction

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj` *(tests skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68beca34ccb48326a6510533b35374bf