### PR TITLE
Make message dialogs asynchronous

### DIFF
--- a/src/DocFinder.App/Services/IMessageDialogService.cs
+++ b/src/DocFinder.App/Services/IMessageDialogService.cs
@@ -1,9 +1,11 @@
+using System.Threading.Tasks;
+
 namespace DocFinder.App.Services;
 
 public interface IMessageDialogService
 {
-    void ShowInformation(string message, string title = "DocFinder");
-    void ShowWarning(string message, string title = "DocFinder");
-    void ShowError(string message, string title = "DocFinder");
-    bool ShowConfirmation(string message, string title = "DocFinder");
+    Task ShowInformation(string message, string title = "DocFinder");
+    Task ShowWarning(string message, string title = "DocFinder");
+    Task ShowError(string message, string title = "DocFinder");
+    Task<bool> ShowConfirmation(string message, string title = "DocFinder");
 }

--- a/src/DocFinder.App/Services/MessageDialogService.cs
+++ b/src/DocFinder.App/Services/MessageDialogService.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using MessageBox = Wpf.Ui.Controls.MessageBox;
 using MessageBoxResult = Wpf.Ui.Controls.MessageBoxResult;
 
@@ -5,7 +6,7 @@ namespace DocFinder.App.Services;
 
 public sealed class MessageDialogService : IMessageDialogService
 {
-    public void ShowInformation(string message, string title = "DocFinder")
+    public async Task ShowInformation(string message, string title = "DocFinder")
     {
         var messageBox = new MessageBox
         {
@@ -14,10 +15,10 @@ public sealed class MessageDialogService : IMessageDialogService
             CloseButtonText = "OK"
         };
 
-        messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+        await messageBox.ShowDialogAsync();
     }
 
-    public void ShowWarning(string message, string title = "DocFinder")
+    public async Task ShowWarning(string message, string title = "DocFinder")
     {
         var messageBox = new MessageBox
         {
@@ -26,10 +27,10 @@ public sealed class MessageDialogService : IMessageDialogService
             CloseButtonText = "OK"
         };
 
-        messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+        await messageBox.ShowDialogAsync();
     }
 
-    public void ShowError(string message, string title = "DocFinder")
+    public async Task ShowError(string message, string title = "DocFinder")
     {
         var messageBox = new MessageBox
         {
@@ -38,10 +39,10 @@ public sealed class MessageDialogService : IMessageDialogService
             CloseButtonText = "OK"
         };
 
-        messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+        await messageBox.ShowDialogAsync();
     }
 
-    public bool ShowConfirmation(string message, string title = "DocFinder")
+    public async Task<bool> ShowConfirmation(string message, string title = "DocFinder")
     {
         var messageBox = new MessageBox
         {
@@ -51,7 +52,7 @@ public sealed class MessageDialogService : IMessageDialogService
             SecondaryButtonText = "No"
         };
 
-        var result = messageBox.ShowDialogAsync().GetAwaiter().GetResult();
+        var result = await messageBox.ShowDialogAsync();
         return result == MessageBoxResult.Primary;
     }
 }

--- a/src/DocFinder.App/Views/Pages/SearchPage.xaml.cs
+++ b/src/DocFinder.App/Views/Pages/SearchPage.xaml.cs
@@ -71,17 +71,17 @@ public partial class SearchPage : INavigableView<SearchViewModel>
 
     private async void Menu_Reindex_Click(object sender, RoutedEventArgs e)
     {
-        if (!_dialogs.ShowConfirmation("Přeindexovat všechny dokumenty?", "DocFinder"))
+        if (!await _dialogs.ShowConfirmation("Přeindexovat všechny dokumenty?", "DocFinder"))
             return;
 
         try
         {
             await _indexer.ReindexAllAsync();
-            _dialogs.ShowInformation("Přeindexování dokončeno", "DocFinder");
+            await _dialogs.ShowInformation("Přeindexování dokončeno", "DocFinder");
         }
         catch (Exception ex)
         {
-            _dialogs.ShowError($"Přeindexování selhalo: {ex.Message}", "DocFinder");
+            await _dialogs.ShowError($"Přeindexování selhalo: {ex.Message}", "DocFinder");
         }
     }
 
@@ -137,7 +137,7 @@ public partial class SearchPage : INavigableView<SearchViewModel>
             openDetail.IsEnabled = hasDoc;
     }
 
-    private void OpenFileDetail_Click(object sender, RoutedEventArgs e)
+    private async void OpenFileDetail_Click(object sender, RoutedEventArgs e)
     {
         var doc = _viewModel.SelectedDocument;
         if (doc == null)
@@ -145,7 +145,7 @@ public partial class SearchPage : INavigableView<SearchViewModel>
 
         var info = new FileInfo(doc.Path);
         var detail = $"Název: {info.Name}\nTyp: {info.Extension}\nVelikost: {info.Length} B\nZměněno: {info.LastWriteTime}";
-        _dialogs.ShowInformation(detail, "Detail souboru");
+        await _dialogs.ShowInformation(detail, "Detail souboru");
     }
 
     private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## Summary
- turn message dialog service methods into async Tasks and await message boxes
- await dialog invocations in SearchPage to keep UI responsive

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed889f75483269da8fcf229d5500e