### PR TITLE
Use WebView2 for PDF viewing

### DIFF
--- a/src/DocFinder.App/DocFinder.App.csproj
+++ b/src/DocFinder.App/DocFinder.App.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="WPF-UI.DependencyInjection" Version="4.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2210.55" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Assets\wpfui-icon-256.png" />


### PR DESCRIPTION
## Summary
- replace legacy `WebBrowser` PDF viewer with `WebView2`
- initialize WebView2 asynchronously and handle missing runtime
- add WebView2 NuGet package

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed88acb0c83269e673e6046c643d6