### PR TITLE
Fix WPFUI namespace usage to resolve XAML errors

### DIFF
--- a/src/DocFinder.App/Views/Layout/BodyView.xaml
+++ b/src/DocFinder.App/Views/Layout/BodyView.xaml
@@ -17,7 +17,6 @@
         Padding="42,0,42,0"
         BreadcrumbBar="{Binding ElementName=BreadcrumbBar}"
         FooterMenuItemsSource="{Binding ViewModel.FooterMenuItems, Mode=OneWay}"
-        FooterMenuItemTemplate="{StaticResource NavigationItemTemplate}"
         FrameMargin="0"
         IsBackButtonVisible="Visible"
         IsPaneToggleVisible="True"

--- a/src/DocFinder.App/Views/Layout/FooterView.xaml
+++ b/src/DocFinder.App/Views/Layout/FooterView.xaml
@@ -2,12 +2,12 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
-    <ui:StackPanel Background="{DynamicResource ApplicationBackgroundBrush}">
-        <ui:Separator />
-        <ui:TextBlock
+    <StackPanel Background="{DynamicResource ApplicationBackgroundBrush}">
+        <Separator />
+        <TextBlock
             Margin="12,8"
             HorizontalAlignment="Center"
             Foreground="{DynamicResource ApplicationForegroundBrush}"
             Text="{Binding FooterText}" />
-    </ui:StackPanel>
+    </StackPanel>
 </UserControl>

--- a/src/DocFinder.App/Views/Pages/DashboardPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DashboardPage.xaml
@@ -1,4 +1,4 @@
-<ui:Page
+<Page
     x:Class="DocFinder.App.Views.Pages.DashboardPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -46,5 +46,5 @@
             <layout:FooterView />
         </layout:MainLayout.Footer>
     </layout:MainLayout>
-</ui:Page>
+</Page>
 

--- a/src/DocFinder.App/Views/Pages/DataPage.xaml
+++ b/src/DocFinder.App/Views/Pages/DataPage.xaml
@@ -1,4 +1,4 @@
-<ui:Page
+<Page
     x:Class="DocFinder.App.Views.Pages.DataPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -32,5 +32,5 @@
             <layout:FooterView />
         </layout:MainLayout.Footer>
     </layout:MainLayout>
-</ui:Page>
+</Page>
 

--- a/src/DocFinder.App/Views/Pages/FileDetailPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FileDetailPage.xaml
@@ -1,4 +1,4 @@
-<ui:Page
+<Page
     x:Class="DocFinder.App.Views.Pages.FileDetailPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -26,7 +26,7 @@
         <layout:MainLayout.Body>
             <StackPanel Margin="12">
                 <TextBlock FontSize="20" FontWeight="Medium" Text="File details" />
-                <ui:Separator Margin="0,8" />
+                <Separator Margin="0,8" />
                 <TextBlock Text="{Binding ViewModel.SelectedFile.Name}" />
                 <TextBlock Text="{Binding ViewModel.SelectedFile.Path}" />
             </StackPanel>
@@ -35,5 +35,5 @@
             <layout:FooterView />
         </layout:MainLayout.Footer>
     </layout:MainLayout>
-</ui:Page>
+</Page>
 

--- a/src/DocFinder.App/Views/Pages/FilesPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FilesPage.xaml
@@ -1,4 +1,4 @@
-<ui:Page
+<Page
     x:Class="DocFinder.App.Views.Pages.FilesPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -48,5 +48,5 @@
             <layout:FooterView />
         </layout:MainLayout.Footer>
     </layout:MainLayout>
-</ui:Page>
+</Page>
 

--- a/src/DocFinder.App/Views/Pages/ProtocolDetailPage.xaml
+++ b/src/DocFinder.App/Views/Pages/ProtocolDetailPage.xaml
@@ -1,4 +1,4 @@
-<ui:Page
+<Page
     x:Class="DocFinder.App.Views.Pages.ProtocolDetailPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -26,7 +26,7 @@
         <layout:MainLayout.Body>
             <StackPanel Margin="12">
                 <TextBlock FontSize="20" FontWeight="Medium" Text="Protocol details" />
-                <ui:Separator Margin="0,8" />
+                <Separator Margin="0,8" />
                 <TextBlock Text="{Binding ViewModel.SelectedProtocol.Name}" />
                 <TextBlock Text="{Binding ViewModel.SelectedProtocol.Description}" />
             </StackPanel>
@@ -35,5 +35,5 @@
             <layout:FooterView />
         </layout:MainLayout.Footer>
     </layout:MainLayout>
-</ui:Page>
+</Page>
 

--- a/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/ProtocolsPage.xaml
@@ -1,4 +1,4 @@
-<ui:Page
+<Page
     x:Class="DocFinder.App.Views.Pages.ProtocolsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -32,5 +32,5 @@
             <layout:FooterView />
         </layout:MainLayout.Footer>
     </layout:MainLayout>
-</ui:Page>
+</Page>
 

--- a/src/DocFinder.App/Views/Pages/SearchPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SearchPage.xaml
@@ -1,4 +1,4 @@
-<ui:Page
+<Page
     x:Class="DocFinder.App.Views.Pages.SearchPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -12,7 +12,7 @@
     d:DataContext="{d:DesignInstance vm:SearchViewModel, IsDesignTimeCreatable=False}"
     mc:Ignorable="d">
 
-    <ui:Page.Resources>
+    <Page.Resources>
         <converters:FileSizeConverter x:Key="FileSizeConverter" />
         <converters:UtcToLocalConverter x:Key="UtcToLocalConverter" />
 
@@ -54,7 +54,7 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
-    </ui:Page.Resources>
+    </Page.Resources>
 
     <layout:MainLayout Background="{DynamicResource SurfaceBackgroundBrush}">
         <layout:MainLayout.Header>
@@ -204,8 +204,8 @@
 
         <layout:MainLayout.Footer>
             <Border Background="{DynamicResource ApplicationBackgroundBrush}">
-                <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
+                <TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
             </Border>
         </layout:MainLayout.Footer>
     </layout:MainLayout>
-</ui:Page>
+</Page>

--- a/src/DocFinder.App/Views/Pages/SettingsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SettingsPage.xaml
@@ -1,4 +1,4 @@
-<ui:Page
+<Page
     x:Class="DocFinder.App.Views.Pages.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -73,5 +73,5 @@
             <layout:FooterView />
         </layout:MainLayout.Footer>
     </layout:MainLayout>
-</ui:Page>
+</Page>
 

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -3,7 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout;assembly=DocFinder.App"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="DocFinder"
     Width="300"
     Height="200"
@@ -31,7 +31,7 @@
 
         <layout:MainLayout.Footer>
             <Border Background="{DynamicResource ApplicationBackgroundBrush}">
-                <ui:TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
+                <TextBlock Margin="12,8" HorizontalAlignment="Center" Text="© 2024 DocFinder" />
             </Border>
         </layout:MainLayout.Footer>
     </layout:MainLayout>

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml
@@ -7,7 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Windows"
-    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout;assembly=DocFinder.App"
+    xmlns:layout="clr-namespace:DocFinder.App.Views.Layout"
     Title="{Binding ViewModel.ApplicationTitle, Mode=OneWay}"
     Width="1100"
     Height="650"


### PR DESCRIPTION
## Summary
- replace WPFUI `Page` tags with standard WPF `Page`
- use base `StackPanel`, `Separator`, and `TextBlock` controls
- remove unsupported `FooterMenuItemTemplate` and simplify layout namespaces

## Testing
- ⚠️ `dotnet build` *(missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68bed99f5d7083269df3ab7aef4fd813