### PR TITLE
Ensure view XAML files are treated as WPF pages

### DIFF
--- a/src/DocFinder.App/DocFinder.App.csproj
+++ b/src/DocFinder.App/DocFinder.App.csproj
@@ -29,6 +29,24 @@
     <Resource Include="Assets\wpfui-icon-1024.png" />
   </ItemGroup>
   <ItemGroup>
+    <Page Include="Views/Layout/*.xaml" />
+    <Compile Update="Views/Layout/*.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="Views/Pages/*.xaml" />
+    <Compile Update="Views/Pages/*.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="Views/Windows/*.xaml" />
+    <Compile Update="Views/Windows/*.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\DocFinder.Domain\DocFinder.Domain.csproj" />
     <ProjectReference Include="..\DocFinder.Indexing\DocFinder.Indexing.csproj" />
     <ProjectReference Include="..\DocFinder.Catalog\DocFinder.Catalog.csproj" />


### PR DESCRIPTION
## Summary
- Include Layout, Pages, and Windows XAML files as `Page` items in DocFinder.App
- Link corresponding code-behind files with `DependentUpon`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee38da6a48326a1632482464674ad