### PR TITLE
Fix XAML namespaces for converters and view models

### DIFF
--- a/src/DocFinder.App/Views/Pages/SearchPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SearchPage.xaml
@@ -5,8 +5,8 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages;assembly=DocFinder.App"
-    xmlns:converters="clr-namespace:DocFinder.App.Converters;assembly=DocFinder.App"
+    xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages"
+    xmlns:converters="clr-namespace:DocFinder.App.Converters"
     Title="SearchPage"
     d:DataContext="{d:DesignInstance vm:SearchViewModel, IsDesignTimeCreatable=False}"
     mc:Ignorable="d">

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml
@@ -6,7 +6,7 @@
     xmlns:local="clr-namespace:DocFinder.App.Views.Windows"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Windows"
+    xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Windows;assembly=DocFinder.App"
     Title="{Binding ApplicationTitle}"
     Width="1100"
     Height="650"


### PR DESCRIPTION
## Summary
- fix FileSizeConverter namespace declaration in SearchPage
- ensure MainWindow uses correct ViewModel namespace

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68bfda72486083268ecb1f9b517d1098