### PR TITLE
Refactor FilesPage to adhere to MVVM

### DIFF
--- a/src/DocFinder.App/ViewModels/Pages/FilesViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Pages/FilesViewModel.cs
@@ -2,16 +2,36 @@ using System;
 using System.Collections.ObjectModel;
 using DocFinder.Domain;
 using DocFinder.App.ViewModels.Entities;
+using DocFinder.App.Services;
+using DocFinder.App.Views.Pages;
 using Wpf.Ui.Abstractions.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace DocFinder.App.ViewModels.Pages;
 
 public partial class FilesViewModel : ObservableObject, INavigationAware
 {
     private bool _isInitialized;
+    private readonly INavigationService _navigationService;
+
+    public FilesViewModel(INavigationService navigationService)
+        => _navigationService = navigationService;
 
     public ObservableCollection<FileViewModel> Files { get; } = new();
+
+    [ObservableProperty]
+    private FileViewModel? selectedFile;
+
+    [RelayCommand]
+    private void OpenFile(FileViewModel? file)
+    {
+        if (file is null)
+            return;
+
+        NavigationState.SelectedFile = file;
+        _navigationService.Navigate(typeof(FileDetailPage));
+    }
 
     public Task OnNavigatedToAsync()
     {

--- a/src/DocFinder.App/Views/Pages/FilesPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FilesPage.xaml
@@ -16,7 +16,12 @@
     mc:Ignorable="d">
 
     <Grid>
-        <ListView ItemsSource="{Binding ViewModel.Files}">
+        <ListView ItemsSource="{Binding Files}" SelectedItem="{Binding SelectedFile}">
+            <ListView.InputBindings>
+                <MouseBinding Gesture="LeftDoubleClick"
+                              Command="{Binding OpenFileCommand}"
+                              CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=ListView}}" />
+            </ListView.InputBindings>
             <ListView.ItemTemplate>
                 <DataTemplate>
                     <Border Margin="4" Padding="8" BorderThickness="1" CornerRadius="4" BorderBrush="{DynamicResource ControlStrokeColorDefaultBrush}">
@@ -27,11 +32,6 @@
                     </Border>
                 </DataTemplate>
             </ListView.ItemTemplate>
-            <ListView.ItemContainerStyle>
-                <Style TargetType="ListViewItem">
-                    <EventSetter Event="MouseDoubleClick" Handler="OnFileDoubleClick" />
-                </Style>
-            </ListView.ItemContainerStyle>
         </ListView>
     </Grid>
 </Page>

--- a/src/DocFinder.App/Views/Pages/FilesPage.xaml.cs
+++ b/src/DocFinder.App/Views/Pages/FilesPage.xaml.cs
@@ -1,33 +1,17 @@
-using System.Windows.Controls;
-using System.Windows.Input;
-using DocFinder.App.Services;
-using DocFinder.App.ViewModels.Entities;
 using DocFinder.App.ViewModels.Pages;
 using Wpf.Ui.Abstractions.Controls;
-using Wpf.Ui;
 
 namespace DocFinder.App.Views.Pages;
 
 public partial class FilesPage : INavigableView<FilesViewModel>
 {
-    private readonly INavigationService _navigationService;
     public FilesViewModel ViewModel { get; }
 
-    public FilesPage(FilesViewModel viewModel, INavigationService navigationService)
+    public FilesPage(FilesViewModel viewModel)
     {
         ViewModel = viewModel;
-        _navigationService = navigationService;
-        DataContext = this;
+        DataContext = ViewModel;
         InitializeComponent();
-    }
-
-    private void OnFileDoubleClick(object sender, MouseButtonEventArgs e)
-    {
-        if (sender is ListViewItem { DataContext: FileViewModel file })
-        {
-            NavigationState.SelectedFile = file;
-            _navigationService.Navigate(typeof(FileDetailPage));
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- move file navigation logic from FilesPage code-behind into FilesViewModel
- bind FilesPage directly to FilesViewModel and invoke navigation via command
- simplify FilesPage code-behind to only set DataContext

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found; tests run but skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bff024b9cc83269330641a61219d8e