### PR TITLE
Add startup loading window

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -76,6 +76,9 @@ public partial class App
 
     private async void OnStartup(object sender, StartupEventArgs e)
     {
+        var loadingWindow = new LoadingWindow();
+        loadingWindow.Show();
+
         // Load user settings before any services are started so that other
         // services (like the file watcher) receive the correct configuration.
         var settings = Services.GetRequiredService<ISettingsService>();
@@ -89,6 +92,8 @@ public partial class App
         ApplicationThemeManager.Apply(theme);
 
         await _host.StartAsync();
+
+        loadingWindow.Close();
 
         var navigation = Services.GetRequiredService<INavigationService>();
         var mainWindow = Services.GetRequiredService<MainWindow>();

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -1,0 +1,20 @@
+<ui:FluentWindow
+    x:Class="DocFinder.App.Views.Windows.LoadingWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    Title="Loading"
+    ResizeMode="NoResize"
+    WindowStartupLocation="CenterScreen"
+    WindowStyle="None"
+    ShowInTaskbar="False"
+    Topmost="True"
+    Width="300"
+    Height="200">
+    <Grid Background="{DynamicResource ApplicationBackgroundBrush}">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+            <ui:ProgressRing Width="48" Height="48" IsIndeterminate="True" />
+            <TextBlock Text="Loading..." Margin="0,12,0,0" HorizontalAlignment="Center" />
+        </StackPanel>
+    </Grid>
+</ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
@@ -1,0 +1,11 @@
+using Wpf.Ui.Controls;
+
+namespace DocFinder.App.Views.Windows;
+
+public partial class LoadingWindow : FluentWindow
+{
+    public LoadingWindow()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary
- show a simple loading splash window before initializing the main UI
- close splash once host services and settings have loaded

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj --no-build` *(hangs after skipping tests, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68bfff26fdd883268031d30709dc45a0