### PR TITLE
Add startup timeouts and async watcher disposal

### DIFF
--- a/src/DocFinder.Indexing/IWatcherService.cs
+++ b/src/DocFinder.Indexing/IWatcherService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace DocFinder.Indexing;
 
-public interface IWatcherService : IDisposable
+public interface IWatcherService : IAsyncDisposable
 {
     void Start();
     void Stop();


### PR DESCRIPTION
## Summary
- guard startup with logging, timeouts, and clearer errors
- dispose services asynchronously to avoid blocking watcher worker

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c0107261d883268ff35fee1be37f3b