### PR TITLE
Add post-startup background service and loading status

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -36,6 +36,7 @@ public partial class App
         {
             services.AddHostedService<ApplicationHostService>();
             services.AddHostedService<AutomaticIndexingService>();
+            services.AddHostedService<PostStartupBackgroundService>();
             services.AddSingleton<ITrayService, TrayService>();
             services.AddSingleton<ISettingsService, SettingsService>();
             services.AddSingleton<ISearchService, LuceneSearchService>();
@@ -79,6 +80,7 @@ public partial class App
     {
         var loadingWindow = new LoadingWindow();
         loadingWindow.Show();
+        loadingWindow.SetStatus("Loading settings...");
 
         try
         {
@@ -93,6 +95,7 @@ public partial class App
                 logger.LogInformation("Starting settings load");
                 await settings.LoadAsync(settingsCts.Token);
                 logger.LogInformation("Settings loaded");
+                loadingWindow.SetStatus("Starting host...");
             }
             catch (OperationCanceledException ex)
             {
@@ -118,6 +121,7 @@ public partial class App
                 logger.LogInformation("Starting host");
                 await _host.StartAsync(hostCts.Token);
                 logger.LogInformation("Host started");
+                loadingWindow.SetStatus("Initializing UI...");
             }
             catch (OperationCanceledException ex)
             {

--- a/src/DocFinder.App/Services/PostStartupBackgroundService.cs
+++ b/src/DocFinder.App/Services/PostStartupBackgroundService.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using DocFinder.App.Views.Windows;
+
+namespace DocFinder.App.Services;
+
+public class PostStartupBackgroundService : BackgroundService
+{
+    private readonly MainWindow _mainWindow;
+    private readonly ILogger<PostStartupBackgroundService> _logger;
+
+    public PostStartupBackgroundService(MainWindow mainWindow, ILogger<PostStartupBackgroundService> logger)
+    {
+        _mainWindow = mainWindow;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_mainWindow.IsLoaded)
+        {
+            var tcs = new TaskCompletionSource();
+            void LoadedHandler(object? sender, RoutedEventArgs e)
+            {
+                _mainWindow.Loaded -= LoadedHandler;
+                tcs.SetResult();
+            }
+            _mainWindow.Loaded += LoadedHandler;
+            await tcs.Task;
+        }
+
+        _logger.LogInformation("Post-startup background service is running.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromHours(1), stoppingToken);
+        }
+    }
+}

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -14,7 +14,7 @@
     <Grid Background="{DynamicResource ApplicationBackgroundBrush}">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
             <ui:ProgressRing Width="48" Height="48" IsIndeterminate="True" />
-            <TextBlock Text="Loading..." Margin="0,12,0,0" HorizontalAlignment="Center" />
+            <TextBlock x:Name="StatusText" Text="Loading..." Margin="0,12,0,0" HorizontalAlignment="Center" />
         </StackPanel>
     </Grid>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
@@ -8,4 +8,9 @@ public partial class LoadingWindow : FluentWindow
     {
         InitializeComponent();
     }
+
+    public void SetStatus(string message)
+    {
+        Dispatcher.Invoke(() => StatusText.Text = message);
+    }
 }


### PR DESCRIPTION
## Summary
- Add `PostStartupBackgroundService` to defer background work until the main window is loaded
- Display startup progress messages in the loading window

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c013ed73d083269870389328d7ee20