### PR TITLE
feat: add startup progress bar

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -80,6 +80,7 @@ public partial class App
     {
         var loadingWindow = new LoadingWindow();
         loadingWindow.Show();
+        loadingWindow.SetProgress(0);
         loadingWindow.SetStatus("Loading settings...");
 
         try
@@ -95,6 +96,7 @@ public partial class App
                 logger.LogInformation("Starting settings load");
                 await settings.LoadAsync(settingsCts.Token);
                 logger.LogInformation("Settings loaded");
+                loadingWindow.SetProgress(33);
                 loadingWindow.SetStatus("Starting host...");
             }
             catch (OperationCanceledException ex)
@@ -121,6 +123,7 @@ public partial class App
                 logger.LogInformation("Starting host");
                 await _host.StartAsync(hostCts.Token);
                 logger.LogInformation("Host started");
+                loadingWindow.SetProgress(66);
                 loadingWindow.SetStatus("Initializing UI...");
             }
             catch (OperationCanceledException ex)
@@ -140,6 +143,7 @@ public partial class App
             navigation.SetNavigationControl(mainWindow.GetNavigation());
             navigation.Navigate(typeof(SearchPage));
             mainWindow.Show();
+            loadingWindow.SetProgress(100);
         }
         catch (Exception ex)
         {

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -12,9 +12,9 @@
     Width="300"
     Height="200">
     <Grid Background="{DynamicResource ApplicationBackgroundBrush}">
-        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-            <ui:ProgressRing Width="48" Height="48" IsIndeterminate="True" />
-            <TextBlock x:Name="StatusText" Text="Loading..." Margin="0,12,0,0" HorizontalAlignment="Center" />
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="250">
+            <ProgressBar x:Name="Progress" Height="20" Minimum="0" Maximum="100" />
+            <TextBlock x:Name="StatusText" Text="Loading..." Margin="0,12,0,0" HorizontalAlignment="Center" TextAlignment="Center" />
         </StackPanel>
     </Grid>
 </ui:FluentWindow>

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
@@ -13,4 +13,9 @@ public partial class LoadingWindow : FluentWindow
     {
         Dispatcher.Invoke(() => StatusText.Text = message);
     }
+
+    public void SetProgress(double value)
+    {
+        Dispatcher.Invoke(() => Progress.Value = value);
+    }
 }


### PR DESCRIPTION
## Summary
- show progress bar during application startup
- display progress updates for settings load, host start and UI init

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c01a2012d8832680cf09f25e7c4173