### PR TITLE
feat(startup): keep UI responsive during startup

### DIFF
--- a/src/DocFinder.App/Services/ApplicationHostService.cs
+++ b/src/DocFinder.App/Services/ApplicationHostService.cs
@@ -44,10 +44,12 @@ public class ApplicationHostService : IHostedService
         {
             _ = Task.Run(async () =>
             {
-                _logger.LogInformation("Starting initial reindexation");
                 try
                 {
-                    await _indexer.ReindexAllAsync(cancellationToken);
+                    await Task.Delay(1000);
+                    _logger.LogInformation("Starting initial reindexation");
+                    using var reindexCts = new CancellationTokenSource();
+                    await _indexer.ReindexAllAsync(reindexCts.Token);
                     _logger.LogInformation("Initial reindexation completed");
                     _tray.ShowNotification("DocFinder", "Initial indexation completed");
                 }
@@ -56,7 +58,7 @@ public class ApplicationHostService : IHostedService
                     _logger.LogError(ex, "Initial reindexation failed");
                     _tray.ShowNotification("DocFinder", "Initial indexation failed");
                 }
-            }, cancellationToken);
+            });
         }
 
         return Task.CompletedTask;

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml.cs
@@ -11,11 +11,11 @@ public partial class LoadingWindow : FluentWindow
 
     public void SetStatus(string message)
     {
-        Dispatcher.Invoke(() => StatusText.Text = message);
+        Dispatcher.BeginInvoke(new Action(() => StatusText.Text = message));
     }
 
     public void SetProgress(double value)
     {
-        Dispatcher.Invoke(() => Progress.Value = value);
+        Dispatcher.BeginInvoke(new Action(() => Progress.Value = value));
     }
 }


### PR DESCRIPTION
## Summary
- offload settings load and host start to background task with logging
- update loading window to use non-blocking dispatcher for status and progress
- delay initial reindexation and avoid UI-thread cancellation tokens

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c01f3ef3048326a7a263940b7a85ed