### PR TITLE
feat: enhance loading screen

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -96,7 +96,7 @@ public partial class App
                 settingsSw.Stop();
                 logger.LogInformation("Settings loaded in {Elapsed} ms", settingsSw.ElapsedMilliseconds);
                 loadingWindow.SetProgress(33);
-                loadingWindow.SetStatus("Starting host...");
+                loadingWindow.SetStatus("Applying database migrations...");
 
                 //MIGRACE – před startem hosta, v samostatném scope, bez dalších otevřených připojení
                 logger.LogInformation("Applying database migrations");
@@ -116,6 +116,7 @@ public partial class App
                 migrateSw.Stop();
                 logger.LogInformation("Migrations applied in {Elapsed} ms", migrateSw.ElapsedMilliseconds);
                 loadingWindow.SetProgress(50);
+                loadingWindow.SetStatus("Starting host...");
 
                 // Teprve teď startuj hosta
                 logger.LogInformation("Starting host");

--- a/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/LoadingWindow.xaml
@@ -14,7 +14,7 @@
     <Grid Background="{DynamicResource ApplicationBackgroundBrush}">
         <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Width="250">
             <ProgressBar x:Name="Progress" Height="20" Minimum="0" Maximum="100" />
-            <TextBlock x:Name="StatusText" Text="Loading..." Margin="0,12,0,0" HorizontalAlignment="Center" TextAlignment="Center" />
+            <TextBlock x:Name="StatusText" Text="Loading..." Margin="0,12,0,0" HorizontalAlignment="Center" TextAlignment="Center" Foreground="White" />
         </StackPanel>
     </Grid>
 </ui:FluentWindow>


### PR DESCRIPTION
## Summary
- make loading screen text white for visibility
- show database migration phase before starting host

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj --no-build` *(fails: MSB4019: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03ad08f948326b75352602a12bde5