### PR TITLE
Fix navigation startup timing to avoid NullReference

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -142,7 +142,7 @@ public partial class App
             var mainWindow = Services.GetRequiredService<MainWindow>();
             mainWindow.SetServiceProvider(Services);
             navigation.SetNavigationControl(mainWindow.GetNavigation());
-            navigation.Navigate(typeof(SearchPage));
+            mainWindow.Loaded += (_, _) => navigation.Navigate(typeof(SearchPage));
             mainWindow.Show();
             uiSw.Stop();
             logger.LogInformation("UI initialized in {Elapsed} ms", uiSw.ElapsedMilliseconds);


### PR DESCRIPTION
## Summary
- Ensure navigation occurs after main window is loaded to prevent NullReference when starting up

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c051333d448326adff41aec3032a59