### PR TITLE
refactor: migrate viewmodels to CommunityToolkit.Mvvm

### DIFF
--- a/src/DocFinder.App/Services/IDocumentOpener.cs
+++ b/src/DocFinder.App/Services/IDocumentOpener.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace DocFinder.App.Services;
+
+/// <summary>
+/// Provides an abstraction for opening documents using the host operating system.
+/// </summary>
+public interface IDocumentOpener
+{
+    /// <summary>
+    /// Opens the specified file using the default associated application.
+    /// </summary>
+    /// <param name="path">Full path to the file.</param>
+    void Open(string path);
+}
+

--- a/src/DocFinder.App/ViewModels/Entities/FileItem.cs
+++ b/src/DocFinder.App/ViewModels/Entities/FileItem.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace DocFinder.App.ViewModels.Entities;
+
+/// <summary>
+/// Lightweight file representation for list displays.
+/// </summary>
+public sealed record FileItem(Guid Id, string Path, string Name);
+

--- a/src/DocFinder.App/ViewModels/Entities/ProtocolItem.cs
+++ b/src/DocFinder.App/ViewModels/Entities/ProtocolItem.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace DocFinder.App.ViewModels.Entities;
+
+/// <summary>
+/// Lightweight protocol representation for lists.
+/// </summary>
+public sealed record ProtocolItem(Guid Id, string Title, string ReferenceNumber);
+

--- a/src/DocFinder.App/ViewModels/Pages/DashboardViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Pages/DashboardViewModel.cs
@@ -1,14 +1,15 @@
-﻿namespace DocFinder.App.ViewModels.Pages
-{
-    public partial class DashboardViewModel : ObservableObject
-    {
-        [ObservableProperty]
-        private int _counter = 0;
+namespace DocFinder.App.ViewModels.Pages;
 
-        [RelayCommand]
-        private void OnCounterIncrement()
-        {
-            Counter++;
-        }
-    }
+/// <summary>
+/// Simple dashboard view model with a counter.
+/// </summary>
+public partial class DashboardViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private int _counter;
+
+    /// <summary>Increments the counter.</summary>
+    [RelayCommand]
+    private void CounterIncrement() => Counter++;
 }
+

--- a/src/DocFinder.App/ViewModels/Windows/MainWindowViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Windows/MainWindowViewModel.cs
@@ -1,83 +1,150 @@
-using System;
 using System.Collections.ObjectModel;
+using System.Linq;
+using DocFinder.App.Services;
 using DocFinder.App.Views.Pages;
+using Wpf.Ui;
+using Wpf.Ui.Appearance;
 using Wpf.Ui.Controls;
 
-namespace DocFinder.App.ViewModels.Windows
+namespace DocFinder.App.ViewModels.Windows;
+
+/// <summary>
+/// View model for the application's main window.
+/// </summary>
+public partial class MainWindowViewModel : ObservableObject
 {
-    public partial class MainWindowViewModel : ObservableObject
+    private readonly INavigationService _navigationService;
+    private readonly IThemeService _themeService;
+    private readonly ISnackbarService _snackbarService;
+    private readonly IMessageDialogService _dialogService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MainWindowViewModel"/> class.
+    /// </summary>
+    public MainWindowViewModel(
+        INavigationService navigationService,
+        IThemeService themeService,
+        ISnackbarService snackbarService,
+        IMessageDialogService dialogService)
     {
-        public MainWindowViewModel()
+        _navigationService = navigationService;
+        _themeService = themeService;
+        _snackbarService = snackbarService;
+        _dialogService = dialogService;
+
+        ApplicationTitle = "DocFinder";
+        IsDarkTheme = _themeService.IsDark();
+        BuildMenu();
+    }
+
+    /// <summary>Application title displayed in the window.</summary>
+    [ObservableProperty]
+    private string _applicationTitle;
+
+    /// <summary>Indicates whether dark theme is active.</summary>
+    [ObservableProperty]
+    private bool _isDarkTheme;
+
+    [ObservableProperty]
+    private object? _selectedItem;
+
+    /// <summary>Navigation menu items.</summary>
+    public ObservableCollection<object> MenuItems { get; } = new();
+
+    /// <summary>Footer navigation menu items.</summary>
+    public ObservableCollection<object> FooterMenuItems { get; } = new();
+
+    /// <summary>Footer text displayed at the bottom of the window.</summary>
+    [ObservableProperty]
+    private string _footerText = $"© {DateTime.Now.Year} DocFinder";
+
+    private void BuildMenu()
+    {
+        MenuItems.Add(new NavigationViewItem
         {
+            Content = "Home",
+            Tag = "dashboard",
+            Icon = new SymbolIcon(SymbolRegular.Home24),
+            TargetPageType = typeof(DashboardPage)
+        });
+        MenuItems.Add(new NavigationViewItem
+        {
+            Content = "Data",
+            Tag = "data",
+            Icon = new SymbolIcon(SymbolRegular.DataHistogram24),
+            TargetPageType = typeof(DataPage)
+        });
+        MenuItems.Add(new NavigationViewItem
+        {
+            Content = "Protocols",
+            Tag = "protocols",
+            Icon = new SymbolIcon(SymbolRegular.DocumentBulletList24),
+            TargetPageType = typeof(ProtocolsPage)
+        });
+        MenuItems.Add(new NavigationViewItem
+        {
+            Content = "Files",
+            Tag = "files",
+            Icon = new SymbolIcon(SymbolRegular.Document24),
+            TargetPageType = typeof(FilesPage)
+        });
+        MenuItems.Add(new NavigationViewItem
+        {
+            Content = "Search",
+            Tag = "search",
+            Icon = new SymbolIcon(SymbolRegular.Search24),
+            TargetPageType = typeof(SearchPage)
+        });
+
+        FooterMenuItems.Add(new NavigationViewItem
+        {
+            Content = "Settings",
+            Tag = "settings",
+            Icon = new SymbolIcon(SymbolRegular.Settings24),
+            TargetPageType = typeof(SettingsPage)
+        });
+        FooterMenuItems.Add(new NavigationViewItem
+        {
+            Content = "About",
+            Tag = "about",
+            Icon = new SymbolIcon(SymbolRegular.Info24)
+        });
+    }
+
+    partial void OnIsDarkThemeChanged(bool value)
+    {
+        _themeService.Set(value ? ThemeType.Dark : ThemeType.Light);
+        var message = value ? "Dark theme enabled" : "Light theme enabled";
+        _snackbarService.Show(message);
+    }
+
+    /// <summary>Navigates to a page based on the provided tag.</summary>
+    [RelayCommand]
+    private void NavigateByTag(string tag)
+    {
+        var item = MenuItems.Concat(FooterMenuItems)
+            .OfType<NavigationViewItem>()
+            .FirstOrDefault(i => string.Equals(i.Tag as string, tag, StringComparison.OrdinalIgnoreCase));
+
+        if (item?.TargetPageType is Type page)
+        {
+            _navigationService.Navigate(page);
         }
-        [ObservableProperty]
-        private string _applicationTitle = "WPF UI - DocFinder";
-
-        [ObservableProperty]
-        private ObservableCollection<NavigationViewItem> _menuItems = new()
+        else if (string.Equals(tag, "about", StringComparison.OrdinalIgnoreCase))
         {
-            new()
-            {
-                Content = "Home",
-                Icon = new SymbolIcon(SymbolRegular.Home24),
-                TargetPageType = typeof(DashboardPage)
-            },
-            new()
-            {
-                Content = "Data",
-                Icon = new SymbolIcon(SymbolRegular.DataHistogram24),
-                TargetPageType = typeof(DataPage)
-            },
-            new()
-            {
-                Content = "Protocols",
-                Icon = new SymbolIcon(SymbolRegular.DocumentBulletList24),
-                TargetPageType = typeof(ProtocolsPage)
-            },
-            new()
-            {
-                Content = "Files",
-                Icon = new SymbolIcon(SymbolRegular.Document24),
-                TargetPageType = typeof(FilesPage)
-            },
-            new()
-            {
-                Content = "Search",
-                Icon = new SymbolIcon(SymbolRegular.Search24),
-                TargetPageType = typeof(SearchPage)
-            }
-        };
-
-        [ObservableProperty]
-        private ObservableCollection<NavigationViewItem> _footerMenuItems = new()
-        {
-            new()
-            {
-                Content = "Settings",
-                Icon = new SymbolIcon(SymbolRegular.Settings24),
-                TargetPageType = typeof(SettingsPage)
-            }
-        };
-
-        [ObservableProperty]
-        private ObservableCollection<MenuItem> _trayMenuItems = new()
-        {
-            new MenuItem { Header = "Home", Tag = "tray_home" }
-        };
-
-        [ObservableProperty]
-        private string _footerText = $"© {DateTime.Now.Year} DocFinder";
-
-        [RelayCommand]
-        private void OpenFile()
-        {
-            // TODO: Implement file open logic
-        }
-
-        [RelayCommand]
-        private void EditItem()
-        {
-            // TODO: Implement edit logic
+            OpenAbout();
         }
     }
+
+    /// <summary>Navigates to the settings page.</summary>
+    [RelayCommand]
+    private void OpenSettings() => _navigationService.Navigate(typeof(SettingsPage));
+
+    /// <summary>Displays basic application information.</summary>
+    [RelayCommand]
+    private async Task OpenAbout()
+    {
+        await _dialogService.ShowInformation("DocFinder", "About");
+    }
 }
+


### PR DESCRIPTION
## Summary
- Refactor main window to use navigation, theme service and snackbar with RelayCommands
- Modernize settings, search, files, protocols and dashboard view models with ObservableProperty/RelayCommand
- Add document opener service and lightweight FileItem/ProtocolItem records

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06077f4c08326a2921c9aee2c8457