### PR TITLE
Fix WPF UI control usage and remove unsupported properties

### DIFF
--- a/src/DocFinder.App/Views/Pages/SettingsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SettingsPage.xaml
@@ -18,8 +18,9 @@
         <ui:TextBlock Grid.Row="0" Text="Settings" FontSize="28" FontWeight="Bold" Margin="0,0,0,16"/>
 
         <StackPanel Grid.Row="1" Orientation="Vertical" >
-            <ui:Card Header="Paths" Padding="16" Margin="0,0,0,16">
+            <ui:Card Padding="16" Margin="0,0,0,16">
                 <StackPanel>
+                    <ui:TextBlock Text="Paths" FontWeight="Bold" Margin="0,0,0,12"/>
                     <ui:TextBlock Text="Source Folder"/>
                     <ui:TextBox Text="{Binding ViewModel.Settings.SourceRoot, UpdateSourceTrigger=PropertyChanged}"/>
 
@@ -35,27 +36,29 @@
                 </StackPanel>
             </ui:Card>
 
-            <ui:Card Header="Indexing &amp; search" Padding="16" Margin="0,0,0,16">
+            <ui:Card Padding="16" Margin="0,0,0,16">
                 <StackPanel>
+                    <ui:TextBlock Text="Indexing &amp; search" FontWeight="Bold" Margin="0,0,0,12"/>
                     <ui:TextBlock Text="Polling Interval (minutes)"/>
                     <ui:TextBox Text="{Binding ViewModel.Settings.PollingMinutes, UpdateSourceTrigger=PropertyChanged}"/>
 
-                    <ui:CheckBox Margin="0,12,0,0" Content="Enable OCR" IsChecked="{Binding ViewModel.Settings.EnableOcr}"/>
-                    <ui:CheckBox Content="Auto index on startup" IsChecked="{Binding ViewModel.Settings.AutoIndexOnStartup}"/>
-                    <ui:CheckBox Content="Use fuzzy search" IsChecked="{Binding ViewModel.Settings.UseFuzzySearch}"/>
+                    <CheckBox Margin="0,12,0,0" Content="Enable OCR" IsChecked="{Binding ViewModel.Settings.EnableOcr}"/>
+                    <CheckBox Content="Auto index on startup" IsChecked="{Binding ViewModel.Settings.AutoIndexOnStartup}"/>
+                    <CheckBox Content="Use fuzzy search" IsChecked="{Binding ViewModel.Settings.UseFuzzySearch}"/>
 
                     <ui:TextBlock Margin="0,12,0,0" Text="Page Size"/>
                     <ui:TextBox Text="{Binding ViewModel.Settings.PageSize, UpdateSourceTrigger=PropertyChanged}"/>
                 </StackPanel>
             </ui:Card>
 
-            <ui:Card Header="Appearance" Padding="16">
+            <ui:Card Padding="16">
                 <StackPanel>
-                    <ui:ComboBox SelectedValue="{Binding ViewModel.Settings.Theme}" SelectedValuePath="Tag" Margin="0,0,0,12">
-                        <ui:ComboBoxItem Content="Light" Tag="Light"/>
-                        <ui:ComboBoxItem Content="Dark" Tag="Dark"/>
-                        <ui:ComboBoxItem Content="Auto" Tag="Auto"/>
-                    </ui:ComboBox>
+                    <ui:TextBlock Text="Appearance" FontWeight="Bold" Margin="0,0,0,12"/>
+                    <ComboBox SelectedValue="{Binding ViewModel.Settings.Theme}" SelectedValuePath="Tag" Margin="0,0,0,12">
+                        <ComboBoxItem Content="Light" Tag="Light"/>
+                        <ComboBoxItem Content="Dark" Tag="Dark"/>
+                        <ComboBoxItem Content="Auto" Tag="Auto"/>
+                    </ComboBox>
 
                     <ui:Button Content="Save" Appearance="Primary" Command="{Binding ViewModel.SaveCommand}" Margin="0,0,0,12"/>
 

--- a/src/DocFinder.App/Views/Windows/MainWindow.xaml
+++ b/src/DocFinder.App/Views/Windows/MainWindow.xaml
@@ -25,42 +25,36 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <!-- TitleBar: použij Trailing místo RightContent -->
+        <!-- TitleBar with toggle for switching theme -->
         <ui:TitleBar Grid.Row="0"
                  Title="{Binding ApplicationTitle}"
                  CloseWindowByDoubleClickOnIcon="True">
             <ui:TitleBar.Icon>
                 <ui:ImageIcon Source="pack://application:,,,/Assets/wpfui-icon-256.png"/>
             </ui:TitleBar.Icon>
-            <ui:TitleBar.Trailing>
+            <ui:TitleBar.TrailingContent>
                 <ui:ToggleSwitch IsChecked="{Binding IsDarkTheme}" Content="Dark"/>
-            </ui:TitleBar.Trailing>
+            </ui:TitleBar.TrailingContent>
         </ui:TitleBar>
 
-        <!-- NavigationView bez child obsahu, odkazuje na Frame -->
+        <!-- NavigationView hosting application pages -->
         <ui:NavigationView Grid.Row="1"
                        x:Name="RootNavigation"
                        PaneDisplayMode="Left"
                        IsPaneToggleVisible="True"
                        IsBackButtonVisible="Visible"
                        MenuItemsSource="{Binding MenuItems}"
-                       FooterMenuItemsSource="{Binding FooterMenuItems}"
-                       Frame="{Binding ElementName=RootFrame}">
+                       FooterMenuItemsSource="{Binding FooterMenuItems}">
             <ui:NavigationView.Header>
                 <Grid Margin="42,24,42,12">
                     <ui:BreadcrumbBar x:Name="BreadcrumbBar"/>
                 </Grid>
             </ui:NavigationView.Header>
-            <!-- ContentOverlay mùže zùstat, ale ne vkládej další layout children mimo povolené -->
+            <!-- ContentOverlay holds transient components like snackbars -->
             <ui:NavigationView.ContentOverlay>
                 <ui:SnackbarPresenter x:Name="SnackbarPresenter"/>
             </ui:NavigationView.ContentOverlay>
         </ui:NavigationView>
-
-        <!-- Host pro stránky: mimo NavigationView -->
-        <Frame x:Name="RootFrame"
-           Grid.Row="1"
-           NavigationUIVisibility="Hidden"/>
 
         <!-- Footer -->
         <Border Grid.Row="2" Background="{DynamicResource ApplicationBackgroundBrush}">


### PR DESCRIPTION
## Summary
- use standard WPF controls instead of non-existent WPF-UI CheckBox/ComboBox variants
- drop obsolete Frame usage and update TitleBar trailing content

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0784deec08326ab1c3de5d1d9abda