### PR TITLE
Fix file property access and theme handling

### DIFF
--- a/src/DocFinder.App/ViewModels/Pages/FilesViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Pages/FilesViewModel.cs
@@ -33,7 +33,7 @@ public partial class FilesViewModel : ObservableObject
         Files.Clear();
         var files = await _repository.ListAsync(ct: ct);
         foreach (var f in files)
-            Files.Add(new FileItem(f.FileId, f.Path, f.FileName));
+            Files.Add(new FileItem(f.FileId, f.FilePath, f.Name));
     }
 
     /// <summary>Opens the specified file using the document opener service.</summary>

--- a/src/DocFinder.App/ViewModels/Pages/SettingsViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Pages/SettingsViewModel.cs
@@ -5,7 +5,6 @@ using DocFinder.Domain.Settings;
 using DocFinder.Indexing;
 using DocFinder.App.Services;
 using Wpf.Ui.Appearance;
-using Wpf.Ui;
 
 namespace DocFinder.App.ViewModels;
 
@@ -17,7 +16,6 @@ public partial class SettingsViewModel : ObservableObject
     private readonly ISettingsService _settingsService;
     private readonly IWatcherService _watcherService;
     private readonly IIndexer _indexer;
-    private readonly IThemeService _themeService;
 
     /// <summary>Current application settings.</summary>
     [ObservableProperty]
@@ -36,13 +34,11 @@ public partial class SettingsViewModel : ObservableObject
     public SettingsViewModel(
         ISettingsService settingsService,
         IWatcherService watcherService,
-        IIndexer indexer,
-        IThemeService themeService)
+        IIndexer indexer)
     {
         _settingsService = settingsService;
         _watcherService = watcherService;
         _indexer = indexer;
-        _themeService = themeService;
 
         Settings = settingsService.Current;
         WatchedRootsText = string.Join(Environment.NewLine, Settings.WatchedRoots);
@@ -120,12 +116,12 @@ public partial class SettingsViewModel : ObservableObject
     private void ApplyTheme(string? themeName)
     {
         Settings.Theme = themeName;
-        var type = themeName?.Equals("Dark", StringComparison.OrdinalIgnoreCase) == true
-            ? ThemeType.Dark
-            : themeName?.Equals("Auto", StringComparison.OrdinalIgnoreCase) == true
-                ? ThemeType.System
-                : ThemeType.Light;
-        _themeService.Set(type);
+        if (themeName?.Equals("Dark", StringComparison.OrdinalIgnoreCase) == true)
+            ApplicationThemeManager.Apply(ApplicationTheme.Dark);
+        else if (themeName?.Equals("Auto", StringComparison.OrdinalIgnoreCase) == true)
+            ApplicationThemeManager.ApplySystemTheme();
+        else
+            ApplicationThemeManager.Apply(ApplicationTheme.Light);
     }
 }
 

--- a/src/DocFinder.App/ViewModels/Windows/MainWindowViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Windows/MainWindowViewModel.cs
@@ -14,7 +14,6 @@ namespace DocFinder.App.ViewModels.Windows;
 public partial class MainWindowViewModel : ObservableObject
 {
     private readonly INavigationService _navigationService;
-    private readonly IThemeService _themeService;
     private readonly ISnackbarService _snackbarService;
     private readonly IMessageDialogService _dialogService;
 
@@ -23,17 +22,15 @@ public partial class MainWindowViewModel : ObservableObject
     /// </summary>
     public MainWindowViewModel(
         INavigationService navigationService,
-        IThemeService themeService,
         ISnackbarService snackbarService,
         IMessageDialogService dialogService)
     {
         _navigationService = navigationService;
-        _themeService = themeService;
         _snackbarService = snackbarService;
         _dialogService = dialogService;
 
         ApplicationTitle = "DocFinder";
-        IsDarkTheme = _themeService.IsDark();
+        IsDarkTheme = ApplicationThemeManager.GetAppTheme() == ApplicationTheme.Dark;
         BuildMenu();
     }
 
@@ -113,9 +110,9 @@ public partial class MainWindowViewModel : ObservableObject
 
     partial void OnIsDarkThemeChanged(bool value)
     {
-        _themeService.Set(value ? ThemeType.Dark : ThemeType.Light);
+        ApplicationThemeManager.Apply(value ? ApplicationTheme.Dark : ApplicationTheme.Light);
         var message = value ? "Dark theme enabled" : "Light theme enabled";
-        _snackbarService.Show(message);
+        _snackbarService.Show("Theme", message, ControlAppearance.Success);
     }
 
     /// <summary>Navigates to a page based on the provided tag.</summary>

--- a/src/DocFinder.App/Views/Pages/FileDetailPage.xaml
+++ b/src/DocFinder.App/Views/Pages/FileDetailPage.xaml
@@ -21,7 +21,7 @@
         <ui:Card Grid.Row="1" Padding="16">
             <StackPanel>
                 <ui:TextBlock Text="{Binding ViewModel.SelectedFile.Name}" FontSize="20" FontWeight="Bold"/>
-                <ui:TextBlock Text="{Binding ViewModel.SelectedFile.Path}" Margin="0,12,0,0"/>
+                <ui:TextBlock Text="{Binding ViewModel.SelectedFile.FilePath}" Margin="0,12,0,0"/>
             </StackPanel>
         </ui:Card>
     </Grid>

--- a/src/DocFinder.App/Views/Pages/SearchPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SearchPage.xaml
@@ -98,7 +98,7 @@
                 <Grid Grid.Row="2">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
-                        <ColumnDefinition Width="320"/>
+                        <ColumnDefinition x:Name="DetailColumn" Width="320"/>
                     </Grid.ColumnDefinitions>
 
                     <ui:DataGrid x:Name="ResultsGrid"


### PR DESCRIPTION
## Summary
- correct file path and name usage for file listings and details
- fix theme toggling and snackbar notification
- name search detail column for responsive layout

## Testing
- `dotnet test src/DocFinder.Tests/DocFinder.Tests.csproj`
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c084e558a88326b82d75d79848ed2c