### PR TITLE
Fix SettingsViewModel namespace

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -15,7 +15,6 @@ using DocFinder.App.Views.Windows;
 using DocFinder.App.Views.Pages;
 using DocFinder.App.ViewModels.Pages;
 using DocFinder.App.ViewModels.Windows;
-using DocFinder.App.ViewModels;
 using DocFinder.Search;
 using DocFinder.Catalog;
 using DocFinder.Indexing;

--- a/src/DocFinder.App/ViewModels/Pages/SettingsViewModel.cs
+++ b/src/DocFinder.App/ViewModels/Pages/SettingsViewModel.cs
@@ -6,7 +6,7 @@ using DocFinder.Indexing;
 using DocFinder.App.Services;
 using Wpf.Ui.Appearance;
 
-namespace DocFinder.App.ViewModels;
+namespace DocFinder.App.ViewModels.Pages;
 
 /// <summary>
 /// View model backing the application settings page.

--- a/src/DocFinder.App/Views/Pages/SettingsPage.xaml
+++ b/src/DocFinder.App/Views/Pages/SettingsPage.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-    xmlns:vm="clr-namespace:DocFinder.App.ViewModels;assembly=DocFinder.App"
+    xmlns:vm="clr-namespace:DocFinder.App.ViewModels.Pages;assembly=DocFinder.App"
     Title="SettingsPage"
     d:DataContext="{d:DesignInstance vm:SettingsViewModel, IsDesignTimeCreatable=False}"
     mc:Ignorable="d">

--- a/src/DocFinder.App/Views/Pages/SettingsPage.xaml.cs
+++ b/src/DocFinder.App/Views/Pages/SettingsPage.xaml.cs
@@ -1,4 +1,4 @@
-using DocFinder.App.ViewModels;
+using DocFinder.App.ViewModels.Pages;
 using Wpf.Ui.Abstractions.Controls;
 
 namespace DocFinder.App.Views.Pages;


### PR DESCRIPTION
## Summary
- fix SettingsViewModel namespace and update XAML references

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c087bea1d4832692c5896303e0f6f3