### PR TITLE
Implement document opener service

### DIFF
--- a/src/DocFinder.App/App.xaml.cs
+++ b/src/DocFinder.App/App.xaml.cs
@@ -63,6 +63,7 @@ public partial class App
                     sp.GetRequiredService<IIndexer>(),
                     sp.GetRequiredService<ILogger<WatcherService>>()));
             services.AddSingleton<IDocumentViewService, DocumentViewService>();
+            services.AddSingleton<IDocumentOpener, DocumentOpener>();
             services.AddSingleton<IMessageDialogService, MessageDialogService>();
             services.AddSingleton<ISnackbarService, SnackbarService>();
             services.AddSingleton<INavigationService, NavigationService>();

--- a/src/DocFinder.App/Services/DocumentOpener.cs
+++ b/src/DocFinder.App/Services/DocumentOpener.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics;
+
+namespace DocFinder.App.Services;
+
+/// <summary>
+/// Provides functionality to open documents using the default application.
+/// </summary>
+public sealed class DocumentOpener : IDocumentOpener
+{
+    /// <inheritdoc />
+    public void Open(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return;
+
+        var info = new ProcessStartInfo
+        {
+            FileName = path,
+            UseShellExecute = true
+        };
+
+        try
+        {
+            Process.Start(info);
+        }
+        catch
+        {
+            // Ignore failures to open the document
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add concrete `DocumentOpener` that launches files with the default application
- register `IDocumentOpener` in `App` service configuration to fix SearchViewModel activation

## Testing
- `dotnet test` *(fails to build WPF app: Microsoft.NET.Sdk.WindowsDesktop.targets not found; tests for other projects pass, 26 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c08fb9fe2483269169842d20b7f528